### PR TITLE
fix(qaskills): layout, empty state, and Chinese card intros

### DIFF
--- a/src/pages/[lang]/qaskills/[skillSlug].astro
+++ b/src/pages/[lang]/qaskills/[skillSlug].astro
@@ -69,6 +69,7 @@ const text = lang === "zh-cn" ? {
   catWorkflow: "工作流",
   catPlus: "Plus",
   installPanel: "安装与调用",
+  onThisPage: "本页导航",
 } : {
   home: "Home",
   list: "QA Skills",
@@ -94,6 +95,7 @@ const text = lang === "zh-cn" ? {
   catWorkflow: "Workflow",
   catPlus: "Plus",
   installPanel: "Install & call",
+  onThisPage: "On this page",
 };
 
 const categoryLabel =
@@ -160,6 +162,14 @@ const skillSchema = {
 };
 const showRawTab = Boolean(skill.rawSkillMarkdown || skill.sourceSkillUrl);
 const visibleSections = SECTION_KEYS.filter((key) => Boolean(skill.sections[key]));
+const tocHeadings = [
+  ...visibleSections.map((key) => ({
+    depth: 2 as const,
+    slug: `section-${key}`,
+    text: SECTION_LABELS[key][localeKey],
+  })),
+  { depth: 2 as const, slug: "install-section", text: text.installPanel },
+];
 ---
 
 <Base
@@ -199,7 +209,7 @@ const visibleSections = SECTION_KEYS.filter((key) => Boolean(skill.sections[key]
 
         <div id="panel-guide" class="tab-panel" role="tabpanel">
           {visibleSections.map((key) => (
-            <section class="detail-section">
+            <section class="detail-section" id={`section-${key}`}>
               <h2>{SECTION_LABELS[key][localeKey]}</h2>
               <div class="prose" set:html={skill.sectionHtml[key]} />
             </section>
@@ -227,14 +237,8 @@ const visibleSections = SECTION_KEYS.filter((key) => Boolean(skill.sections[key]
           </div>
         )}
 
-        <div class="ad-slot-250">
-          <GoogleAd />
-        </div>
-      </div>
-
-      <aside class="detail-aside" id="install-section">
-        <details class="install-collapse" open>
-          <summary>{text.installPanel}</summary>
+        <section class="install-block" id="install-section">
+          <h2>{text.installPanel}</h2>
           <div class="installer-panel" id="installer-panel" data-default-lang={installerLang}>
             <div class="installer-row">
               <p class="installer-label">{text.platform}</p>
@@ -286,10 +290,10 @@ const visibleSections = SECTION_KEYS.filter((key) => Boolean(skill.sections[key]
               </div>
             </div>
           </div>
-        </details>
+        </section>
 
         {related.length > 0 && (
-          <section class="related-block">
+          <section class="related-block related-block--main">
             <h2>{text.related}</h2>
             <ul>
               {related.map((item) => (
@@ -302,6 +306,23 @@ const visibleSections = SECTION_KEYS.filter((key) => Boolean(skill.sections[key]
             </ul>
           </section>
         )}
+
+        <div class="ad-slot-250">
+          <GoogleAd />
+        </div>
+      </div>
+
+      <aside class="detail-aside" aria-label={text.onThisPage}>
+        <nav class="elevator" id="skill-elevator">
+          <p class="elevator-title">{text.onThisPage}</p>
+          <ul class="elevator-list">
+            {tocHeadings.map((item) => (
+              <li>
+                <a class="elevator-link" href={`#${item.slug}`} data-elevator-target={item.slug}>{item.text}</a>
+              </li>
+            ))}
+          </ul>
+        </nav>
       </aside>
     </div>
 
@@ -324,18 +345,47 @@ const visibleSections = SECTION_KEYS.filter((key) => Boolean(skill.sections[key]
     const tabButtons = Array.from(document.querySelectorAll(".detail-tab[data-tab]"));
     const panelGuide = document.getElementById("panel-guide");
     const panelRaw = document.getElementById("panel-raw");
+    const activateTab = (tab) => {
+      tabButtons.forEach((b) => {
+        const active = b.getAttribute("data-tab") === tab;
+        b.classList.toggle("is-active", active);
+        b.setAttribute("aria-selected", active ? "true" : "false");
+      });
+      if (panelGuide) panelGuide.hidden = tab !== "guide";
+      if (panelRaw) panelRaw.hidden = tab !== "raw";
+    };
     tabButtons.forEach((btn) => {
-      btn.addEventListener("click", () => {
-        const tab = btn.getAttribute("data-tab");
-        tabButtons.forEach((b) => {
-          const active = b === btn;
-          b.classList.toggle("is-active", active);
-          b.setAttribute("aria-selected", active ? "true" : "false");
-        });
-        if (panelGuide) panelGuide.hidden = tab !== "guide";
-        if (panelRaw) panelRaw.hidden = tab !== "raw";
+      btn.addEventListener("click", () => activateTab(btn.getAttribute("data-tab") || "guide"));
+    });
+
+    const elevatorLinks = Array.from(document.querySelectorAll("[data-elevator-target]"));
+    const setActiveElevator = (slug) => {
+      elevatorLinks.forEach((a) => {
+        a.classList.toggle("is-active", a.getAttribute("data-elevator-target") === slug);
+      });
+    };
+    elevatorLinks.forEach((link) => {
+      link.addEventListener("click", () => {
+        const target = link.getAttribute("data-elevator-target") || "";
+        if (target.startsWith("section-")) activateTab("guide");
+        setActiveElevator(target);
       });
     });
+    const observed = elevatorLinks
+      .map((link) => document.getElementById(link.getAttribute("data-elevator-target") || ""))
+      .filter(Boolean);
+    if (observed.length && "IntersectionObserver" in window) {
+      const io = new IntersectionObserver(
+        (entries) => {
+          const visible = entries
+            .filter((e) => e.isIntersecting)
+            .sort((a, b) => b.intersectionRatio - a.intersectionRatio)[0];
+          if (visible?.target?.id) setActiveElevator(visible.target.id);
+        },
+        { rootMargin: "-20% 0px -55% 0px", threshold: [0.1, 0.35, 0.6] }
+      );
+      observed.forEach((el) => io.observe(el));
+    }
 
     const copyRawBtn = document.getElementById("copy-raw-skill-btn");
     const rawCode = document.getElementById("raw-skill-code");
@@ -534,11 +584,59 @@ const visibleSections = SECTION_KEYS.filter((key) => Boolean(skill.sections[key]
   }
   .detail-layout {
     display: grid;
-    grid-template-columns: minmax(0, 1fr) minmax(280px, 340px);
+    grid-template-columns: minmax(0, 1fr) minmax(160px, 200px);
     gap: 0.85rem;
     align-items: start;
   }
-  .detail-aside { position: sticky; top: 0.75rem; display: grid; gap: 0.75rem; }
+  .detail-aside {
+    position: sticky;
+    top: 0.75rem;
+    display: grid;
+    gap: 0.75rem;
+  }
+  .elevator {
+    border: 1px solid color-mix(in srgb, var(--color-main) 12%, transparent);
+    border-radius: 12px;
+    background: color-mix(in srgb, var(--color-base) 97%, var(--color-main));
+    padding: 0.7rem 0.75rem;
+  }
+  .elevator-title {
+    margin: 0 0 0.45rem;
+    font-size: 0.78rem;
+    font-weight: 800;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    opacity: 0.72;
+  }
+  .elevator-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: 0.2rem;
+  }
+  .elevator-link {
+    display: block;
+    padding: 0.28rem 0.4rem;
+    border-radius: 6px;
+    border-left: 2px solid transparent;
+    color: inherit;
+    text-decoration: none;
+    font-size: 0.86rem;
+    font-weight: 650;
+    line-height: 1.35;
+    opacity: 0.82;
+  }
+  .elevator-link:hover {
+    opacity: 1;
+    background: color-mix(in srgb, var(--color-theme) 8%, transparent);
+  }
+  .elevator-link.is-active {
+    opacity: 1;
+    color: var(--color-theme);
+    border-left-color: var(--color-theme);
+    background: color-mix(in srgb, var(--color-theme) 10%, transparent);
+  }
   .detail-tabs {
     display: flex;
     gap: 0.5rem;
@@ -563,6 +661,7 @@ const visibleSections = SECTION_KEYS.filter((key) => Boolean(skill.sections[key]
     background: color-mix(in srgb, var(--color-base) 97%, var(--color-main));
     padding: 0.8rem;
     margin-bottom: 0.75rem;
+    scroll-margin-top: 1rem;
   }
   .detail-section h2 {
     margin-top: 0;
@@ -627,22 +726,24 @@ const visibleSections = SECTION_KEYS.filter((key) => Boolean(skill.sections[key]
     white-space: inherit;
     word-break: inherit;
   }
-  .install-collapse {
+  .install-block {
     border: 1px solid color-mix(in srgb, var(--color-main) 12%, transparent);
     border-radius: 12px;
     background: color-mix(in srgb, var(--color-base) 97%, var(--color-main));
-    padding: 0.75rem;
+    padding: 0.85rem;
+    margin: 0.85rem 0;
+    scroll-margin-top: 1rem;
   }
-  .install-collapse > summary {
-    cursor: pointer;
-    font-weight: 800;
-    margin-bottom: 0.55rem;
+  .install-block > h2 {
+    margin: 0 0 0.75rem;
+    font-size: clamp(1.15rem, 2vw, 1.35rem);
   }
   .related-block {
     border: 1px solid color-mix(in srgb, var(--color-main) 12%, transparent);
     border-radius: 12px;
     background: color-mix(in srgb, var(--color-base) 97%, var(--color-main));
     padding: 0.75rem;
+    margin-bottom: 0.75rem;
   }
   .related-block h2 {
     margin: 0 0 0.5rem;
@@ -767,7 +868,25 @@ const visibleSections = SECTION_KEYS.filter((key) => Boolean(skill.sections[key]
   :global(.qaskill-detail .code-card code .tok-op) { color: #f58c66; }
   @media (max-width: 900px) {
     .detail-layout { grid-template-columns: 1fr; }
-    .detail-aside { position: static; }
+    .detail-aside { position: static; order: -1; }
+    .elevator {
+      max-height: none;
+    }
+    .elevator-list {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.35rem;
+    }
+    .elevator-link {
+      border-left: 0;
+      border: 1px solid color-mix(in srgb, var(--color-main) 16%, transparent);
+      border-radius: 999px;
+      padding: 0.25rem 0.55rem;
+      font-size: 0.8rem;
+    }
+    .elevator-link.is-active {
+      border-color: var(--color-theme);
+    }
     .detail-header { flex-direction: column; }
     .header-actions { width: 100%; justify-content: flex-start; }
   }

--- a/src/pages/[lang]/qaskills/index.astro
+++ b/src/pages/[lang]/qaskills/index.astro
@@ -377,6 +377,8 @@ const displayNameOf = (skill: (typeof allSkills)[number]) =>
       document.querySelector(".chip[data-evals-toggle]")?.classList.remove("is-active");
       apply();
     });
+
+    apply();
   })();
 </script>
 
@@ -479,6 +481,9 @@ const displayNameOf = (skill: (typeof allSkills)[number]) =>
     padding: 0.9rem;
     border-radius: 12px;
     border: 1px dashed color-mix(in srgb, var(--color-main) 24%, transparent);
+  }
+  .empty-state[hidden] {
+    display: none;
   }
   .quick-grid {
     list-style: none;

--- a/src/utils/qaskills.ts
+++ b/src/utils/qaskills.ts
@@ -261,7 +261,8 @@ export function parseQASkillMarkdown(lang: "en" | "zh-cn", slug: string, body: s
     SECTION_KEYS.map((key) => [key, toHtml(sections[key])])
   ) as Record<SectionKey, string>;
   const description = meta.description;
-  const intro = description || firstBulletText(sections.whenToUse) || title;
+  // Card intros should match page language. YAML description is often English (agent triggers).
+  const intro = firstBulletText(sections.whenToUse) || description || title;
   const category = inferCategory(meta.slug || slug, meta.category);
   const installMarkdown =
     sectionContent(body, "安装") || sectionContent(body, "Install") || "";

--- a/tests/e2e/specs/qaskills.spec.ts
+++ b/tests/e2e/specs/qaskills.spec.ts
@@ -4,6 +4,7 @@ test.describe("QA Skills", () => {
   test("zh-cn index shows search and code-review card metadata", async ({ page }) => {
     await page.goto("/zh-cn/qaskills/");
     await expect(page.locator("#qaskills-search")).toBeVisible();
+    await expect(page.locator("#qaskills-empty")).toBeHidden();
     const card = page.locator('a.card[data-slug="code-review"]');
     await expect(card).toBeVisible();
     await expect(card.locator(".tag-evals")).toBeVisible();
@@ -12,9 +13,11 @@ test.describe("QA Skills", () => {
   test("detail shows Guide section, raw SKILL tab, and install panel", async ({ page }) => {
     await page.goto("/zh-cn/qaskills/api-testing/");
     await expect(page.getByRole("heading", { name: /何时使用|When to Use/ })).toBeVisible();
+    await expect(page.locator("#skill-elevator")).toBeVisible();
     await page.getByRole("tab", { name: /SKILL\.md/i }).click();
     await expect(page.locator(".skill-raw")).toContainText("name: api-testing");
     await expect(page.locator("#copy-raw-skill-btn")).toBeVisible();
+    await expect(page.locator("#install-section")).toBeVisible();
     await expect(page.locator("#installer-panel")).toBeVisible();
     await expect(page.locator("#copy-quick-btn")).toBeVisible();
   });

--- a/tests/unit/qaskillsParse.site.test.ts
+++ b/tests/unit/qaskillsParse.site.test.ts
@@ -56,7 +56,8 @@ describe("parseQASkillMarkdown", () => {
     expect(skill.updatedAt).toBe("2026-08-05");
     expect(skill.sections.whenToUse).toContain("API 测试方案");
     expect(skill.rawSkillMarkdown).toContain("name: api-testing");
-    expect(skill.intro).toContain("API tests");
+    expect(skill.description).toContain("API tests");
+    expect(skill.intro).toContain("需要 API 测试方案");
   });
 
   it("keeps full raw SKILL.md even when fenced content has ## headings", () => {


### PR DESCRIPTION
Move install below Guide with a right-side elevator nav, hide the empty state unless filters match nothing, and prefer localized when-to-use text for skill card intros.