### PR TITLE
refactor(design): consolidate Zenix design system and restructure hom…

### DIFF
--- a/docs/standards/apple-design-redesign.md
+++ b/docs/standards/apple-design-redesign.md
@@ -1,7 +1,9 @@
 # Apple Design 改版规范（后期参考）
 
-**状态：** 探索已完成（分支 `explore-apple-design`）；合并 `main` / 正式上线前需另审  
-**日期：** 2026-07-31（探索落地） / 2026-08-03（本文整理）  
+> **⚠️ 本文已废弃，仅供追溯。** 站点实际采用 Zenix 视觉语言，现行规范见 `docs/standards/zenix-design.md`（2026-08-13 起生效）。本文描述的 Action Blue / 品牌橙 token 与代码现状不符，请勿按本文实施。
+
+**状态：** 已废弃（被 `zenix-design.md` 取代）；原探索分支 `explore-apple-design` 未合并  
+**日期：** 2026-07-31（探索落地） / 2026-08-03（本文整理） / 2026-08-13（标注废弃）  
 **外部参考：** [VoltAgent awesome-design-md · Apple DESIGN.md](https://github.com/VoltAgent/awesome-design-md/blob/main/design-md/apple/DESIGN.md)  
 **关联文档：** `docs/superpowers/specs/2026-07-31-apple-design-exploration-design.md`、`docs/superpowers/plans/2026-07-31-apple-design-exploration.md`
 

--- a/docs/standards/zenix-design.md
+++ b/docs/standards/zenix-design.md
@@ -1,0 +1,104 @@
+# Zenix 设计规范（现行）
+
+**状态：** 现行规范，取代 `docs/standards/apple-design-redesign.md`（该文档已标注废弃，仅供追溯）
+**日期：** 2026-08-13（`design-zenix-consolidation` 分支收敛落定）
+**源文件：** `src/styles/base.css`（token 契约）、`tests/unit/zenixDesignTokens.test.ts`（契约测试）
+
+本文是本站现行视觉语言的成稿规范：写清 token、表面材质、圆角、首页与内容页约定。改视觉先改这里。
+
+---
+
+## 1. 设计语言定位
+
+- **Zenix 冷色 SaaS 知识库风**：indigo 单一主色 + 冷灰 canvas + 细网格背景 + 玻璃页脚
+- 浅色主导（唯一主题）；暗色模式为明确非目标，见 §6
+- 内容优先：内容页（博客/Wiki/Guild/Docs）排版克制，不卡片化；视觉语言主要作用在壳层（顶栏/页脚）与首页
+
+## 2. Design Token 契约
+
+契约测试：`tests/unit/zenixDesignTokens.test.ts`。改 token 必须同步改测试。
+
+### 2.1 颜色
+
+| 角色 | Token | 值 | 用途 |
+| --- | --- | --- | --- |
+| 主色（唯一 accent） | `--color-theme` | `#4f46e5` | 链接、主 CTA、焦点环、强调 |
+| 主色深 | `--color-theme-focus` | `#4338ca` | 聚焦态、渐变深端 |
+| 主色浅 | `--color-theme-light` | `#818cf8` | 渐变浅端、装饰 |
+| 深色表面链接 | `--color-theme-on-dark` | `#a5b4fc` | 顶栏等深色表面上的链接 |
+| 页面底 | `--color-base` | `#f8fafc` | 全站画布 |
+| 墨色 | `--color-main` | `#0f172a` | 正文文字、顶栏背景（off-black） |
+| 表面 | `--color-surface` / `--color-canvas` | `#ffffff` | 卡片、输入框底 |
+| 次级文字 | `--color-text-secondary` / `--text-tertiary` | `#334155` / `#64748b` | 说明文字、元信息 |
+| 弱表面 | `--color-surface-muted` | `#f1f5f9` | 冷灰色带 tint |
+| 边框 | `--color-border` / `--color-border-strong` | `#e2e8f0` / indigo 16% | 卡片边框 / 强调边框 |
+| 语义色 | `--color-caution` / `--color-warn` | `#be123c` / `#f59e0b` | 错误 / 警告，仅语义场景 |
+
+**单一主色规则**：indigo 是唯一 accent。禁止新增第二个 accent 色（原 teal `--color-accent` 已删除）。渐变一律 indigo 系（theme → theme-focus 或 theme → theme-light）。
+
+### 2.2 渐变
+
+| Token | 值 | 用途 |
+| --- | --- | --- |
+| `--gradient-theme` | `linear-gradient(135deg, theme, theme-light)` | 品牌渐变（徽章、装饰、hero 局部） |
+| `--gradient-hero` | indigo 双角淡渐变 + 白→base 纵向 | 首页 hero 背景 |
+
+### 2.3 圆角（四档 + 例外，硬规则）
+
+| 档位 | Token | 适用 |
+| --- | --- | --- |
+| 小 | `--radius-sm` = 8px | 控件、徽章、标签、输入框 |
+| 中 | `--radius-md` = 12px | 常规卡片、面板 |
+| 大 | `--radius-lg` = 18px | 大容器（页脚玻璃卡、hero 面板） |
+| 药丸 | `--radius-xl` = 9999px | 交互药丸（pill-cta、chip、filter-pill） |
+
+例外（允许）：头像/圆形图标 `50%`；滚动条滑块 `2-3px`；直角 `0`（如跳转链接角标）。**新增界面不得出现这四档之外的散值**；统一写 `var(--radius-*)`。
+
+### 2.4 阴影 / 间距 / 字体
+
+- 阴影：`--shadow-sm/md/lg`（slate 色相，禁纯黑阴影）；产品感 `--shadow-product`（indigo 16%）
+- 间距：`--sp-xl/l/m/s/xs`（64/32/16/8px，<480px 收紧）+ `--space-*` 微间距；区块间距 `--spacing-section: 80px`
+- 字体：`--font-heading`（Sora，标题/强调数字）、`--font-sans`（Noto Sans，正文）。中文字体走系统栈。Google Fonts 用 preload + 异步换载模式加载
+- 背景网格：indigo 3.5% 双向网格，42px 格；禁止改回 16px 点阵（有测试守护）
+
+## 3. 表面材质（壳层）
+
+| 表面 | 规则 |
+| --- | --- |
+| 顶栏 | 白色磨砂玻璃（`color-mix(canvas 78%)` + `backdrop-filter: blur(22px)` + hairline 底边），深色文字；子菜单/语言面板为浅色玻璃面板 |
+| 页脚 | 冷灰渐变底 + 白色玻璃卡（`backdrop-filter: blur(22px)`，18px 圆角），社交图标悬浮卡片顶边 |
+| 首页色带 | 全宽透明带 + `:nth-of-type(even)` 白→冷灰淡渐变交替；色带类名 `home-band--white` / `home-band--muted` |
+| 卡片 | 1px hairline 边框 + 白/淡白渐变底 + `--shadow-sm`；hover 上浮 2-4px + indigo 边框，不用重阴影 |
+
+## 4. 首页约定
+
+- **Hero 构成**：标题 + 副标题 + 至多 2 个 CTA（pill-cta）。不得在 hero 里堆入口卡、伪窗口或装饰条
+- **入口职责**：所有内容入口集中在 Explore 区块（`HOME_EXPLORE_CARDS`，zh 7 卡 / en 6 卡）
+- **布局家族不连用**：连续区块不得重复同一布局。首页现有分布：卡片阵列（Explore/Prompts/QA Skills）、行列表（最新文章）、紧凑双列列表（精选项目）、chip cloud（wiki/AIWiki/tags）、任务网格（HomeTaskNavigator）、能力卡（CoreCapabilities）、示例行（HomeProofAndCases）
+- **埋点契约**：首页必须保留 `/blog`、`/wiki`(zh) 或 `/AIWiki`、`/guild`、`/prompts`、`/qaskills` 的链接（`TrackingEvents` 按路径埋点，删区块时检查链接仍可达）
+
+## 5. 图标与文案约定
+
+- **图标**：统一 Material Icons Sharp（`<span class="material-icons-sharp" aria-hidden="true">连字名</span>`），字体已在 Base 布局加载。**禁止 emoji 当图标**（Guild/prompts 已全部替换）
+- **英文破折号**：UI 与英文文案禁用 em-dash（—）与 en-dash 作分隔符；用冒号、逗号或句号。中文正文的标准「——」保留
+- **文案**：中英结构对称，文案统一走 `src/consts.ts` / 页面 i18n 对象，不在模板里散写
+
+## 6. 明确非目标（决策记录）
+
+- 暗色模式（`prefers-color-scheme: dark`）：浅色唯一，契约测试锁定
+- 内容页（博客/Wiki/Guild/Docs 阅读页）版式重排：只继承 token
+- 像素级复刻任何第三方设计
+
+## 7. 变更流程
+
+1. 先改本文件与 `base.css` token，再改壳层/页面
+2. 同步 `tests/unit/zenixDesignTokens.test.ts`
+3. 涉及首页结构时同步 `tests/e2e/specs/apple-home.spec.ts`、`tracking-contract.spec.ts`、`navigation.spec.ts`
+4. `npm run build` + 相关 e2e 通过后方可合入
+
+---
+
+关联文档：
+- 实施记录：`docs/tasks/zenix-design-consolidation-v1.md`
+- 废弃规范：`docs/standards/apple-design-redesign.md`（仅供追溯）
+- 广告位规范：`docs/standards/ads-inventory.md`

--- a/docs/tasks/zenix-design-consolidation-v1.md
+++ b/docs/tasks/zenix-design-consolidation-v1.md
@@ -1,0 +1,50 @@
+# Zenix 设计收敛实施记录 v1
+
+- 分支：`design-zenix-consolidation`（基于 `ads-entry-optimization`）
+- 日期：2026-08-13
+- 规范落点：`docs/standards/zenix-design.md`（现行）、`docs/standards/apple-design-redesign.md`（已标注废弃）
+
+## 背景
+
+站点实际已是 Zenix 风格（indigo + 冷灰 + 玻璃页脚），但设计文档仍是 Apple 版且描述不存在的品牌橙 token。审计发现：双主色、圆角散值 10+ 种、首页 hero 过载 + 伪控制台、首页连续 5 区块同布局、纯黑顶栏、emoji 图标、英文破折号、页脚双 CSS。
+
+用户确认方向：indigo 唯一主色；顶栏保持 Zenix 白玻璃（审计误判为纯黑，实测白玻璃与整体语言自洽）；首页 hero 精简、入口并入 Explore。
+
+## 改动清单
+
+### Token（`src/styles/base.css` + 全站）
+
+- 删除 `--color-accent`（teal #14b8a6），新增 `--color-theme-light`（#818cf8，渐变浅端）
+- `--gradient-theme` / `--gradient-hero` / 背景网格收敛为 indigo 系
+- 全站 15+ 处 teal 引用替换：PageHeadline、Footer、Header、FrameworkCard、guild 文章页、prompts 首页、qaskills 首页、首页（含硬编码 rgba）
+- 圆角归一：四档 token（8/12/18/pill）+ 50% 圆形 + 滚动条豁免；全站约 30 个文件的散值（2/3/4/5/6/7/9/10/14/16/20/22/24/28/50px、0.5/0.75rem）机械归一到 `var(--radius-*)`
+- `tests/unit/zenixDesignTokens.test.ts`：断言改为「indigo 单一主色、teal accent 不存在」
+
+### 首页重组（`src/pages/[lang]/index.astro` + `consts.ts` + 2 个首页组件）
+
+- Hero 精简：只留标题/副标题/2 个 CTA；删除 home-primary-entries（含内联数据）与伪控制台 home-hero-console（含全部 console 样式与移动端规则）；类名 `home-apple-hero` → `home-hero`
+- 入口并入 Explore：`HOME_EXPLORE_CARDS` zh 补 blog 卡（7 张）；en 保持 6 张（blog 已有，wiki 语义由 AIWiki 卡覆盖，en 站内无 /wiki 路径）
+- 布局多样化：最新文章改纵向行列表（5 篇，新增 `.home-post-list` 样式）；精选项目改紧凑双列列表（`.home-project-list`，移动单列）
+- 色带类名 `home-band--parchment` → `home-band--muted`（index、HomeTaskNavigator、HomeProofAndCases）；首页样式块清理死代码
+- 测试同步：`apple-home.spec.ts`（删 console/primary-entry 测试，新增 hero CTA 测试，explore 卡数 zh 7 / en 6，hero 类名）；`tracking-contract.spec.ts`（blog 入口选择器改 hero CTA）；`navigation.spec.ts`（hero 类名）
+- 埋点契约保持：hero CTA 覆盖 /blog 与 /wiki|/AIWiki，Explore 卡覆盖其余路径
+
+### 细节清理
+
+- 顶栏：保持 Zenix 白玻璃 skin（实测生效样式），清理第一块中被覆盖的黑色死样式（原 #000 纯黑规则）
+- emoji → Material Icons Sharp：prompts 首页流程卡 9 个、GuildFeatures（徽章 + 12 图标）、GuildHero、GuildOverviewPage、LearningWorkflow、FrameworkWorkflow、框架页学习路径标题、guild.config.ts 3 个 testType 图标 + 3 处渲染点（TestTypeSection×2、framework 页 badge）、sponsor
+- 英文破折号：copyright 页分隔符改冒号、sponsor 英文句重组、guild 框架页 meta description 改逗号；中文「——」保留
+- 页脚：`Footer.astro` 两套 CSS 合并为单一块（Zenix 玻璃卡为底，保留旧块独有的 lang-toggle/lang-label/footer-nav-group/copyright/tech-* 选择器并 token 化旧色，保留 `position: relative` 与移动端 2 列导航）
+
+### 文档
+
+- 新建 `docs/standards/zenix-design.md`：token 契约、四档圆角硬规则、表面材质、首页约定、图标/文案约定、浅色唯一决策、变更流程
+- `docs/standards/apple-design-redesign.md` 头部标注废弃并指向新规范
+- 本文档（实施记录）
+
+## 验证
+
+- [x] `npm run build`（875 页，exit 0）
+- [x] `npm test`（76/76）+ `cd tests && npm run test:unit`（76/76，含 zenix token 契约测试）
+- [x] e2e：`apple-home`、`tracking-contract`、`navigation`、`header`、`accessibility-contrast`、`accessibility-hard-metrics`、`responsive`、`ad-low-intrusion` 共 92/92 通过
+- [x] preview 程序化目检（Playwright 计算样式断言）：首页 hero 380px、伪控制台/入口卡已移除、Explore zh 7 / en 6、文章行列表 5 行、项目列表桌面 2 列/移动 1 列、白玻璃顶栏（78% 白 + 22px blur + hairline）、页脚玻璃卡 18px、全站无 teal、无 emoji、无横向溢出

--- a/src/components/ArticleShare.astro
+++ b/src/components/ArticleShare.astro
@@ -143,7 +143,7 @@ const facebookUrl = `https://www.facebook.com/sharer/sharer.php?u=${encodedUrl}`
     gap: 0.35rem;
     min-height: 44px;
     padding: 0.5rem 0.75rem;
-    border-radius: 10px;
+    border-radius: var(--radius-sm);
     color: var(--color-main);
     background: color-mix(in srgb, var(--color-main) 8%, transparent);
     border: 1px solid color-mix(in srgb, var(--color-main) 15%, transparent);

--- a/src/components/AuthorStatsCard.astro
+++ b/src/components/AuthorStatsCard.astro
@@ -105,7 +105,7 @@ function formatWords(n: number): string {
 <style>
   .author-stats-card {
     padding: calc(var(--sp-m) * 0.75);
-    border-radius: 16px;
+    border-radius: var(--radius-md);
     background: color-mix(in srgb, var(--color-base) 98%, var(--color-main));
     border: 1px solid color-mix(in srgb, var(--color-theme) 12%, transparent);
     text-align: center;

--- a/src/components/DocsSidebar.astro
+++ b/src/components/DocsSidebar.astro
@@ -86,7 +86,7 @@ const isActive = (itemHref: string) => normalize(itemHref) === current;
   }
   .docs-sidebar-inner {
     border-inline-start: 3px solid color-mix(in srgb, var(--color-theme) 35%, transparent);
-    border-radius: 0 10px 10px 0;
+    border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
     background: color-mix(in srgb, var(--color-base) 96%, var(--color-main));
     padding-inline-start: 0;
   }

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -173,27 +173,37 @@ const footerGroups = [
 </footer>
 
 <style>
+  /* Zenix footer: glass panel on cool gradient */
   .l-footer {
-    background: #f5f5f7;
-    color: #333333;
-    padding-block: 64px;
-    margin-block-start: 0;
     position: relative;
+    margin-block-start: 0;
+    padding-block: 78px 56px;
+    color: var(--color-text-secondary);
+    background:
+      linear-gradient(180deg, rgba(248, 250, 252, 0), rgba(79, 70, 229, 0.055)),
+      var(--color-base);
   }
-  
+
   .footer-container {
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: var(--sp-m);
+    gap: 1.5rem;
+    max-inline-size: 1120px;
+    padding: 34px;
+    border: 1px solid rgba(148, 163, 184, 0.22);
+    border-radius: var(--radius-lg);
+    background: rgba(255, 255, 255, 0.74);
+    box-shadow: var(--shadow-md);
+    backdrop-filter: blur(22px);
   }
 
-  /* 社交链接样式保持翻倍尺寸 */
+  /* 社交链接悬浮在卡片顶边 */
   .social-links {
     display: flex;
     justify-content: center;
     flex-wrap: wrap;
-    gap: 1.5rem;
+    gap: 0.8rem;
     position: absolute;
     top: 0;
     left: 50%;
@@ -206,43 +216,45 @@ const footerGroups = [
     display: flex;
     align-items: center;
     justify-content: center;
-    width: 72px;
-    height: 72px;
-    background: #ffffff;
-    color: #333333;
-    border: 1px solid color-mix(in srgb, #333333 12%, transparent);
+    width: 52px;
+    height: 52px;
+    color: var(--color-text-secondary);
+    border: 1px solid rgba(148, 163, 184, 0.28);
     border-radius: 50%;
-    box-shadow: none;
+    background: rgba(255, 255, 255, 0.88);
+    box-shadow: var(--shadow-sm);
     transition: color 0.2s ease, border-color 0.2s ease;
     text-decoration: none;
     position: relative;
   }
 
   .social-icon svg {
-    width: 32px;
-    height: 32px;
+    width: 23px;
+    height: 23px;
   }
 
   .social-icon:hover,
   .social-icon:focus-visible {
     color: var(--color-theme);
-    border-color: color-mix(in srgb, var(--color-theme) 30%, transparent);
+    border-color: color-mix(in srgb, var(--color-theme) 26%, transparent);
+    background: color-mix(in srgb, var(--color-theme) 8%, white);
+    transform: translateY(-2px);
   }
 
   .lang-toggle {
-    background: #ffffff;
+    background: var(--color-surface);
   }
-  
+
   .lang-label {
     position: absolute;
     bottom: 10px;
     font-size: 0.7rem;
     font-weight: 900;
-    background: #333333;
-    color: #ffffff;
     padding: 2px 4px;
-    border-radius: 4px;
+    border-radius: var(--radius-sm);
     line-height: 1;
+    background: linear-gradient(135deg, var(--color-theme), var(--color-theme-light));
+    color: white;
   }
 
   /* 底部次级导航 */
@@ -250,9 +262,10 @@ const footerGroups = [
     display: grid;
     grid-template-columns: repeat(4, minmax(0, 1fr));
     justify-content: stretch;
-    gap: clamp(1.25rem, 4vw, 3rem);
+    gap: 0.65rem 1rem;
     width: min(960px, 100%);
-    margin-block-start: var(--sp-m);
+    max-width: 920px;
+    margin-block-start: 1.2rem;
   }
 
   .footer-nav-group {
@@ -264,7 +277,7 @@ const footerGroups = [
     font-size: 13px;
     line-height: 1.4;
     font-weight: 700;
-    color: #1d1d1f;
+    color: var(--color-main);
   }
 
   .footer-nav-group ul {
@@ -277,20 +290,24 @@ const footerGroups = [
 
   .footer-nav a,
   .social-links a {
-    color: #333333;
+    color: var(--color-text-secondary);
     font-size: 14px;
     line-height: 2.2;
   }
 
   .footer-nav a {
     text-decoration: none;
-    font-weight: 400;
+    font-weight: 700;
+    line-height: 1.8;
+    padding: 0.18rem 0.35rem;
+    border-radius: 999px;
     transition: color 0.2s ease;
   }
 
   .footer-nav a:hover,
   .footer-nav a:focus-visible {
     color: var(--color-theme);
+    background: color-mix(in srgb, var(--color-theme) 8%, white);
   }
 
   /* 版权与信息区域 */
@@ -300,9 +317,9 @@ const footerGroups = [
     align-items: center;
     gap: 0.75rem;
     padding-block-start: var(--sp-m);
-    border-block-start: 1px solid color-mix(in srgb, #333333 12%, transparent);
+    border-block-start: 1px solid rgba(148, 163, 184, 0.28);
     width: 100%;
-    max-inline-size: 600px;
+    max-inline-size: 760px;
     text-align: center;
   }
 
@@ -311,6 +328,7 @@ const footerGroups = [
     font-size: 14px;
     font-weight: 400;
     letter-spacing: 0.02em;
+    color: var(--color-text-tertiary);
   }
 
   .copyright {
@@ -324,7 +342,7 @@ const footerGroups = [
   }
 
   .copy-link {
-    color: inherit;
+    color: var(--color-main);
     text-decoration: none;
     font-weight: 700;
   }
@@ -357,6 +375,10 @@ const footerGroups = [
     letter-spacing: 0.05em;
   }
 
+  .built-with {
+    color: var(--color-text-tertiary);
+  }
+
   .tech-icons {
     display: flex;
     align-items: center;
@@ -370,7 +392,7 @@ const footerGroups = [
     justify-content: center;
     width: 28px;
     height: 28px;
-    color: #333333;
+    color: var(--color-text-tertiary);
     opacity: 0.7;
     transition: color 0.2s ease, opacity 0.2s ease;
   }
@@ -391,120 +413,6 @@ const footerGroups = [
   }
 
   @media (max-width: 600px) {
-    .social-links {
-      gap: 0.75rem;
-    }
-    .social-icon {
-      width: 56px;
-      height: 56px;
-    }
-    .social-icon svg {
-      width: 24px;
-      height: 24px;
-    }
-    .footer-nav {
-      grid-template-columns: repeat(2, minmax(0, 1fr));
-      gap: 1.4rem 1rem;
-      text-align: start;
-    }
-  }
-
-  /* Zenix-inspired footer panel. */
-  .l-footer {
-    margin-block-start: 0;
-    padding-block: 78px 56px;
-    color: var(--color-text-secondary);
-    background:
-      linear-gradient(180deg, rgba(248, 250, 252, 0), rgba(79, 70, 229, 0.055)),
-      var(--color-base);
-  }
-
-  .footer-container {
-    max-inline-size: 1120px;
-    gap: 1.5rem;
-    padding: 34px;
-    border: 1px solid rgba(148, 163, 184, 0.22);
-    border-radius: 28px;
-    background: rgba(255, 255, 255, 0.74);
-    box-shadow: var(--shadow-md);
-    backdrop-filter: blur(22px);
-  }
-
-  .social-links {
-    gap: 0.8rem;
-  }
-
-  .social-icon {
-    width: 52px;
-    height: 52px;
-    color: var(--color-text-secondary);
-    border-color: rgba(148, 163, 184, 0.28);
-    background: rgba(255, 255, 255, 0.88);
-    box-shadow: var(--shadow-sm);
-  }
-
-  .social-icon svg {
-    width: 23px;
-    height: 23px;
-  }
-
-  .social-icon:hover,
-  .social-icon:focus-visible {
-    color: var(--color-theme);
-    border-color: color-mix(in srgb, var(--color-theme) 26%, transparent);
-    background: color-mix(in srgb, var(--color-theme) 8%, white);
-    transform: translateY(-2px);
-  }
-
-  .lang-label {
-    background: linear-gradient(135deg, var(--color-theme), var(--color-accent));
-    color: white;
-  }
-
-  .footer-nav {
-    max-width: 920px;
-    gap: 0.65rem 1rem;
-    margin-block-start: 1.2rem;
-  }
-
-  .footer-nav a,
-  .social-links a {
-    color: var(--color-text-secondary);
-  }
-
-  .footer-nav a {
-    padding: 0.18rem 0.35rem;
-    border-radius: 999px;
-    font-size: 14px;
-    font-weight: 700;
-    line-height: 1.8;
-  }
-
-  .footer-nav a:hover,
-  .footer-nav a:focus-visible {
-    color: var(--color-theme);
-    background: color-mix(in srgb, var(--color-theme) 8%, white);
-  }
-
-  .footer-info {
-    max-inline-size: 760px;
-    border-block-start-color: rgba(148, 163, 184, 0.28);
-  }
-
-  .footer-slogan,
-  .built-with {
-    color: var(--color-text-tertiary);
-  }
-
-  .copy-link {
-    color: var(--color-main);
-  }
-
-  .tech-icon {
-    color: var(--color-text-tertiary);
-  }
-
-  @media (max-width: 600px) {
     .l-footer {
       padding-block: 64px 40px;
     }
@@ -512,12 +420,22 @@ const footerGroups = [
     .footer-container {
       width: calc(100% - 32px);
       padding: 28px 18px;
-      border-radius: 22px;
+      border-radius: var(--radius-lg);
+    }
+
+    .social-links {
+      gap: 0.75rem;
     }
 
     .social-icon {
       width: 48px;
       height: 48px;
+    }
+
+    .footer-nav {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 1.4rem 1rem;
+      text-align: start;
     }
   }
 </style>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -469,11 +469,7 @@ const mobilePriorityItems = [
     position: sticky;
     top: 0;
     z-index: 100;
-    height: 60px;
-    background: #000;
-    color: #fff;
-    border: none;
-    box-shadow: none;
+    /* 视觉样式见下方 Zenix skin 块（白玻璃顶栏） */
   }
   .l-header::after {
     display: none;
@@ -680,8 +676,8 @@ const mobilePriorityItems = [
     padding: 0.55rem;
     list-style: none;
     border: 1px solid color-mix(in srgb, white 12%, transparent);
-    border-radius: 0.75rem;
-    background: #1d1d1f;
+    border-radius: var(--radius-md);
+    background: var(--color-main);
     box-shadow: 0 12px 28px color-mix(in srgb, black 45%, transparent);
     transform-origin: top center;
     animation: nav-submenu-in 0.16s ease-out;
@@ -725,7 +721,7 @@ const mobilePriorityItems = [
     width: auto;
     min-width: max-content;
     padding: 0.6rem 0.95rem;
-    border-radius: 0.5rem;
+    border-radius: var(--radius-sm);
     color: #fff;
     background: transparent;
     border: 1px solid transparent;
@@ -808,7 +804,7 @@ const mobilePriorityItems = [
     font-weight: 400;
     color: #fff;
     border: none;
-    border-radius: 4px;
+    border-radius: var(--radius-sm);
   }
   .nav-tool :global(.locale-trigger:hover),
   .nav-tool :global(.locale-trigger:focus-visible) {
@@ -823,7 +819,7 @@ const mobilePriorityItems = [
     font-size: 22px;
   }
   .nav-tool :global(.locale-panel) {
-    background: #1d1d1f;
+    background: var(--color-main);
     border: 1px solid color-mix(in srgb, white 12%, transparent);
     box-shadow: 0 12px 28px color-mix(in srgb, black 45%, transparent);
   }
@@ -851,7 +847,7 @@ const mobilePriorityItems = [
     color: #fff;
     background: transparent;
     border: 1px solid transparent;
-    border-radius: 4px;
+    border-radius: var(--radius-sm);
     cursor: pointer;
     transition: background 0.18s ease, opacity 0.18s ease;
   }
@@ -1014,7 +1010,7 @@ const mobilePriorityItems = [
       gap: 0.25rem;
       min-height: 74px;
       padding: 0.6rem 0.35rem;
-      border-radius: 0.5rem;
+      border-radius: var(--radius-sm);
       color: #fff;
       text-align: center;
       text-decoration: none;
@@ -1113,7 +1109,7 @@ const mobilePriorityItems = [
   .site-title-primary,
   .site-title-secondary,
   .site-brand-link > span:not(.site-title-cobrand) {
-    background: linear-gradient(90deg, var(--color-main), var(--color-theme) 55%, var(--color-accent));
+    background: linear-gradient(90deg, var(--color-main), var(--color-theme) 55%, var(--color-theme-light));
     -webkit-background-clip: text;
     background-clip: text;
     color: transparent;

--- a/src/components/PageHeadline.astro
+++ b/src/components/PageHeadline.astro
@@ -18,11 +18,11 @@ const { title, compact = false } = Astro.props;
     padding-block: var(--sp-l) calc(var(--sp-l) + var(--sp-s));
     padding-inline: var(--sp-m);
     text-align: center;
-    border-radius: 24px;
+    border-radius: var(--radius-lg);
     color: var(--color-main);
     background:
       linear-gradient(135deg, color-mix(in srgb, var(--color-theme) 10%, white), transparent 42%),
-      linear-gradient(315deg, color-mix(in srgb, var(--color-accent) 12%, white), transparent 38%),
+      linear-gradient(315deg, color-mix(in srgb, var(--color-theme-light) 12%, white), transparent 38%),
       rgba(255, 255, 255, 0.82);
     border: 1px solid rgba(148, 163, 184, 0.24);
     box-shadow: var(--shadow-md);
@@ -47,7 +47,7 @@ const { title, compact = false } = Astro.props;
     letter-spacing: 0;
     margin: 0;
     line-height: 1.25;
-    background: linear-gradient(90deg, var(--color-main), var(--color-theme) 58%, var(--color-accent));
+    background: linear-gradient(90deg, var(--color-main), var(--color-theme) 58%, var(--color-theme-light));
     -webkit-background-clip: text;
     background-clip: text;
     color: transparent;

--- a/src/components/SearchModal.astro
+++ b/src/components/SearchModal.astro
@@ -511,7 +511,7 @@ const t = useTranslations(locale);
     flex-direction: column;
     gap: 0.35rem;
     padding: 0.82rem 0.95rem;
-    border-radius: 10px;
+    border-radius: var(--radius-sm);
     color: inherit;
     text-decoration: none;
     border: 1px solid transparent;

--- a/src/components/TableOfContents.astro
+++ b/src/components/TableOfContents.astro
@@ -116,7 +116,7 @@ const currentLabel = label.includes("目录") ? "当前：" : "Now:";
   }
   .toc-sidebar--below .toc-nav {
     padding: 0.7rem 0.8rem;
-    border-radius: 10px;
+    border-radius: var(--radius-sm);
     background: color-mix(in srgb, var(--color-theme) 4%, transparent);
     border: 1px solid color-mix(in srgb, var(--color-theme) 10%, transparent);
   }

--- a/src/components/guild/FrameworkCard.astro
+++ b/src/components/guild/FrameworkCard.astro
@@ -212,8 +212,8 @@ const difficultyText = framework.difficulty
   }
 
   .difficulty-badge--intermediate {
-    background: color-mix(in srgb, var(--color-accent) 15%, transparent);
-    color: var(--color-accent);
+    background: color-mix(in srgb, var(--color-theme) 15%, transparent);
+    color: var(--color-theme);
   }
 
   .difficulty-badge--advanced {
@@ -234,7 +234,7 @@ const difficultyText = framework.difficulty
     align-items: center;
     gap: 0.5rem;
     padding: 0.5rem 1rem;
-    border-radius: 6px;
+    border-radius: var(--radius-sm);
     font-size: var(--text-sm);
     font-weight: 500;
     text-decoration: none;

--- a/src/components/guild/FrameworkWorkflow.astro
+++ b/src/components/guild/FrameworkWorkflow.astro
@@ -95,7 +95,8 @@ const steps = isZh
 <div class="fw-workflow">
   <div class="fw-workflow__header">
     <h2 class="fw-workflow__title">
-      {isZh ? '📋 学习工作流程' : '📋 Learning Workflow'}
+      <span class="material-icons-sharp" aria-hidden="true">assignment</span>
+      {isZh ? '学习工作流程' : 'Learning Workflow'}
     </h2>
     <p class="fw-workflow__subtitle">
       {isZh ? '三步完成你的学习之旅' : 'Three steps to complete your learning journey'}
@@ -132,7 +133,7 @@ const steps = isZh
   .fw-workflow {
     background: var(--color-surface);
     border: 1px solid var(--color-border);
-    border-radius: 16px;
+    border-radius: var(--radius-md);
     padding: 1.25rem 1.5rem;
   }
 
@@ -252,7 +253,7 @@ const steps = isZh
     color: var(--color-theme);
     text-decoration: none;
     padding: 0.3em 0.75em;
-    border-radius: 6px;
+    border-radius: var(--radius-sm);
     border: 1px solid color-mix(in srgb, var(--color-theme) 25%, transparent);
     background: color-mix(in srgb, var(--color-theme) 6%, transparent);
     transition: var(--transition-base);

--- a/src/components/guild/GuildFeatures.astro
+++ b/src/components/guild/GuildFeatures.astro
@@ -10,27 +10,27 @@ const { locale } = Astro.props;
 
 const content = {
   'zh-cn': {
-    badge: '🎯 核心特性',
+    badge: '核心特性',
     title: '为什么选择这里',
     features: [
-      { icon: '📚', title: '全生命周期覆盖', description: '从环境搭建到 CI/CD 集成的完整学习路径' },
-      { icon: '🌐', title: '多语言支持', description: '支持 JavaScript、Python、Java 等主流编程语言' },
-      { icon: '📖', title: '完整版 + 精简版', description: '每个框架都提供详细教程和快速入门指南' },
-      { icon: '💡', title: '实战导向', description: '提供 GitHub Demo 项目和最佳实践指导' },
-      { icon: '🚀', title: '持续更新', description: '跟随技术发展，持续更新内容和示例' },
-      { icon: '🔧', title: '可扩展性好', description: '模块化设计，便于学习和实践应用' },
+      { icon: 'menu_book', title: '全生命周期覆盖', description: '从环境搭建到 CI/CD 集成的完整学习路径' },
+      { icon: 'public', title: '多语言支持', description: '支持 JavaScript、Python、Java 等主流编程语言' },
+      { icon: 'auto_stories', title: '完整版 + 精简版', description: '每个框架都提供详细教程和快速入门指南' },
+      { icon: 'lightbulb', title: '实战导向', description: '提供 GitHub Demo 项目和最佳实践指导' },
+      { icon: 'rocket_launch', title: '持续更新', description: '跟随技术发展，持续更新内容和示例' },
+      { icon: 'build', title: '可扩展性好', description: '模块化设计，便于学习和实践应用' },
     ],
   },
   'en': {
-    badge: '🎯 Core Features',
+    badge: 'Core Features',
     title: 'Why Learn Here',
     features: [
-      { icon: '📚', title: 'Full Lifecycle Coverage', description: 'Complete learning paths from setup to CI/CD integration' },
-      { icon: '🌐', title: 'Multi-Language Support', description: 'Support for JavaScript, Python, Java and more' },
-      { icon: '📖', title: 'Complete + Quick Start', description: 'Detailed tutorials and quick start guides for each framework' },
-      { icon: '💡', title: 'Practice-Oriented', description: 'GitHub demo projects and best practice guidance' },
-      { icon: '🚀', title: 'Continuously Updated', description: 'Content and examples updated with technology evolution' },
-      { icon: '🔧', title: 'Highly Extensible', description: 'Modular design for easy learning and practical application' },
+      { icon: 'menu_book', title: 'Full Lifecycle Coverage', description: 'Complete learning paths from setup to CI/CD integration' },
+      { icon: 'public', title: 'Multi-Language Support', description: 'Support for JavaScript, Python, Java and more' },
+      { icon: 'auto_stories', title: 'Complete + Quick Start', description: 'Detailed tutorials and quick start guides for each framework' },
+      { icon: 'lightbulb', title: 'Practice-Oriented', description: 'GitHub demo projects and best practice guidance' },
+      { icon: 'rocket_launch', title: 'Continuously Updated', description: 'Content and examples updated with technology evolution' },
+      { icon: 'build', title: 'Highly Extensible', description: 'Modular design for easy learning and practical application' },
     ],
   },
 };
@@ -40,14 +40,17 @@ const text = content[locale as keyof typeof content] ?? content['en'];
 
 <section class="gf-section">
   <div class="gf-heading">
-    <div class="gf-badge">{text.badge}</div>
+    <div class="gf-badge">
+      <span class="material-icons-sharp" aria-hidden="true">track_changes</span>
+      {text.badge}
+    </div>
     <h2 class="gf-title">{text.title}</h2>
   </div>
 
   <div class="gf-grid">
     {text.features.map((f) => (
       <div class="gf-card">
-        <span class="gf-card__icon" aria-hidden="true">{f.icon}</span>
+        <span class="gf-card__icon material-icons-sharp" aria-hidden="true">{f.icon}</span>
         <h3 class="gf-card__title">{f.title}</h3>
         <p class="gf-card__desc">{f.description}</p>
       </div>
@@ -59,7 +62,7 @@ const text = content[locale as keyof typeof content] ?? content['en'];
   .gf-section {
     background: var(--color-surface);
     border: 1px solid var(--color-border);
-    border-radius: 16px;
+    border-radius: var(--radius-md);
     padding: 1.75rem 1.5rem;
   }
 

--- a/src/components/guild/GuildHero.astro
+++ b/src/components/guild/GuildHero.astro
@@ -15,13 +15,13 @@ const isZh = locale === 'zh-cn';
 
 const content = {
   'zh-cn': {
-    badge: '🚀 测试自动化指南',
+    badge: '测试自动化指南',
     title: '让自动化测试成为你的超能力',
     description: '系统化的学习路径，从入门到进阶，涵盖接口测试、UI 测试和性能测试。选择你感兴趣的框架，开始你的自动化测试之旅。',
     stats: { testTypes: '测试类型', frameworks: '测试框架', learningPaths: '学习路径' },
   },
   'en': {
-    badge: '🚀 Test Automation Guild',
+    badge: 'Test Automation Guild',
     title: 'Make Test Automation Your Superpower',
     description: 'Systematic learning paths from beginner to advanced, covering API testing, UI testing, and performance testing. Choose your framework and start your journey.',
     stats: { testTypes: 'Test Types', frameworks: 'Frameworks', learningPaths: 'Learning Paths' },
@@ -36,7 +36,10 @@ const totalTestTypes = guildConfig.testTypes.length;
 
 <div class="guild-hero">
   <div class="guild-hero__inner">
-    <div class="guild-hero__badge">{text.badge}</div>
+    <div class="guild-hero__badge">
+      <span class="material-icons-sharp" aria-hidden="true">rocket_launch</span>
+      {text.badge}
+    </div>
     <h1 class="guild-hero__title">{text.title}</h1>
     <p class="guild-hero__description">{text.description}</p>
 
@@ -62,7 +65,7 @@ const totalTestTypes = guildConfig.testTypes.length;
 <style>
   .guild-hero {
     padding: 3rem 2rem 2.5rem;
-    border-radius: 20px;
+    border-radius: var(--radius-lg);
     background: color-mix(in srgb, var(--color-theme) 3%, var(--color-base));
     border: 1px solid color-mix(in srgb, var(--color-theme) 12%, transparent);
     position: relative;

--- a/src/components/guild/GuildOverviewPage.astro
+++ b/src/components/guild/GuildOverviewPage.astro
@@ -52,7 +52,10 @@ const visibleTestTypes = guildConfig.testTypes.filter((t) => t.id !== "ui-testin
     <GuildHero locale={locale} />
 
     <div class="filter-card">
-      <div class="filter-card__label">{isZh ? "📚 学习路径" : "📚 Learning Paths"}</div>
+      <div class="filter-card__label">
+        <span class="material-icons-sharp" aria-hidden="true">menu_book</span>
+        {isZh ? "学习路径" : "Learning Paths"}
+      </div>
       <div class="filter-bar" role="group" aria-label={isZh ? "按测试类型筛选" : "Filter by test type"}>
         <button class="filter-pill filter-pill--active" data-filter="all">{isZh ? "全部" : "All"}</button>
         {
@@ -102,7 +105,7 @@ const visibleTestTypes = guildConfig.testTypes.filter((t) => t.id !== "ui-testin
   .filter-card {
     background: var(--color-surface);
     border: 1px solid var(--color-border);
-    border-radius: 16px;
+    border-radius: var(--radius-md);
     padding: 1.25rem 1.5rem;
     display: flex;
     align-items: center;

--- a/src/components/guild/GuildShowcase.astro
+++ b/src/components/guild/GuildShowcase.astro
@@ -143,7 +143,7 @@ const isZh = locale === 'zh-cn';
   .gs-type-block {
     background: rgba(255, 255, 255, 0.78);
     border: 1px solid rgba(148, 163, 184, 0.2);
-    border-radius: 22px;
+    border-radius: var(--radius-lg);
     padding: 24px;
     box-shadow: var(--shadow-sm);
   }
@@ -224,7 +224,7 @@ const isZh = locale === 'zh-cn';
     width: 28px;
     height: 28px;
     object-fit: contain;
-    border-radius: 6px;
+    border-radius: var(--radius-sm);
   }
 
   .gs-fw-lang {

--- a/src/components/guild/LearningWorkflow.astro
+++ b/src/components/guild/LearningWorkflow.astro
@@ -11,7 +11,7 @@ const { locale } = Astro.props;
 
 const content = {
   'zh-cn': {
-    title: '🔄 学习工作流程',
+    title: '学习工作流程',
     subtitle: '三步开始你的自动化测试之旅',
     steps: [
       {
@@ -47,7 +47,7 @@ const content = {
     ],
   },
   'en': {
-    title: '🔄 Learning Workflow',
+    title: 'Learning Workflow',
     subtitle: 'Start your test automation journey in three steps',
     steps: [
       {
@@ -89,7 +89,10 @@ const text = content[locale as keyof typeof content] || content['en'];
 
 <section class="learning-workflow">
   <div class="learning-workflow__header">
-    <h2 class="learning-workflow__title">{text.title}</h2>
+    <h2 class="learning-workflow__title">
+      <span class="material-icons-sharp" aria-hidden="true">sync_alt</span>
+      {text.title}
+    </h2>
     <p class="learning-workflow__subtitle">{text.subtitle}</p>
   </div>
 
@@ -122,7 +125,7 @@ const text = content[locale as keyof typeof content] || content['en'];
   .learning-workflow {
     background: var(--color-surface);
     border: 1px solid var(--color-border);
-    border-radius: 16px;
+    border-radius: var(--radius-md);
     padding: 1.75rem 1.5rem;
   }
 
@@ -154,7 +157,7 @@ const text = content[locale as keyof typeof content] || content['en'];
     position: relative;
     background: var(--color-surface);
     border: 1px solid var(--color-border);
-    border-radius: 16px;
+    border-radius: var(--radius-md);
     padding: 1.5rem;
     transition: var(--transition-base);
   }
@@ -246,7 +249,7 @@ const text = content[locale as keyof typeof content] || content['en'];
     .learning-workflow {
       margin: 3rem 0;
       padding: 2rem 1rem;
-      border-radius: 16px;
+      border-radius: var(--radius-md);
     }
 
     .learning-workflow__header {

--- a/src/components/guild/TestTypeSection.astro
+++ b/src/components/guild/TestTypeSection.astro
@@ -26,7 +26,7 @@ const isZh = locale === 'zh-cn';
 <section class="tts" id={testType.id} data-testtype={testType.id}>
   <!-- Section header -->
   <div class="tts__header">
-    <span class="tts__icon" aria-hidden="true">{testType.icon}</span>
+    <span class="tts__icon material-icons-sharp" aria-hidden="true">{testType.icon}</span>
     <div class="tts__meta">
       <h2 class="tts__title">{testType.title}</h2>
       <p class="tts__desc">{testType.description}</p>
@@ -57,7 +57,7 @@ const isZh = locale === 'zh-cn';
             {fw.icon ? (
               <img src={fw.icon} alt={fw.name} class="fw-card__icon" width="28" height="28" loading="lazy" />
             ) : (
-              <span class="fw-card__icon-fb" aria-hidden="true">{testType.icon}</span>
+              <span class="fw-card__icon-fb material-icons-sharp" aria-hidden="true">{testType.icon}</span>
             )}
             <span class="fw-card__lang">{fw.language}</span>
           </div>
@@ -79,7 +79,7 @@ const isZh = locale === 'zh-cn';
   .tts {
     background: var(--color-surface);
     border: 1px solid var(--color-border);
-    border-radius: 16px;
+    border-radius: var(--radius-md);
     padding: 1.5rem;
     transition: var(--transition-base);
   }
@@ -203,7 +203,7 @@ const isZh = locale === 'zh-cn';
     width: 26px;
     height: 26px;
     object-fit: contain;
-    border-radius: 4px;
+    border-radius: var(--radius-sm);
     flex-shrink: 0;
   }
 
@@ -218,7 +218,7 @@ const isZh = locale === 'zh-cn';
     color: color-mix(in srgb, var(--color-main) 48%, transparent);
     background: color-mix(in srgb, var(--color-main) 7%, transparent);
     padding: 0.12em 0.45em;
-    border-radius: 4px;
+    border-radius: var(--radius-sm);
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;

--- a/src/components/home/HomeProofAndCases.astro
+++ b/src/components/home/HomeProofAndCases.astro
@@ -4,7 +4,7 @@ import { HOME_EXAMPLES } from "@/data/homeTaskEntries";
 interface Props { locale: Lang }
 const { locale } = Astro.props;
 ---
-<section class="home-band home-band--parchment" aria-labelledby="home-proof-title"><div class="home-inner home-proof-inner">
+<section class="home-band home-band--muted" aria-labelledby="home-proof-title"><div class="home-inner home-proof-inner">
   <h2 id="home-proof-title" class="home-band__title">{locale === "zh-cn" ? "从输入到可评审交付物" : "From input to reviewable deliverable"}</h2>
   <p class="home-band__subtitle">{locale === "zh-cn" ? "这些能力用于加速分析与整理，最终结论仍应结合项目上下文和人工评审。" : "These capabilities accelerate analysis and structuring; final decisions still require project context and human review."}</p>
   <ol class="example-grid">{HOME_EXAMPLES[locale].map(example => <li data-home-example={example.key}><p><strong>{locale === "zh-cn" ? "输入" : "Input"}</strong>{example.input}</p><span>→</span><p><strong>{locale === "zh-cn" ? "能力" : "Capability"}</strong>{example.capability}</p><span>→</span><p><strong>{locale === "zh-cn" ? "输出" : "Output"}</strong>{example.output}</p></li>)}</ol>

--- a/src/components/home/HomeTaskNavigator.astro
+++ b/src/components/home/HomeTaskNavigator.astro
@@ -5,7 +5,7 @@ import { HOME_TASK_ENTRIES } from "@/data/homeTaskEntries";
 interface Props { locale: Lang }
 const { locale } = Astro.props;
 ---
-<section class="home-band home-band--parchment home-task-navigator" aria-labelledby="home-task-title">
+<section class="home-band home-band--muted home-task-navigator" aria-labelledby="home-task-title">
   <div class="home-inner">
     <h2 id="home-task-title" class="home-band__title">{locale === "zh-cn" ? "你现在要完成什么测试任务？" : "What QA task do you need to complete?"}</h2>
     <p class="home-band__subtitle">{locale === "zh-cn" ? "从任务出发，直接进入对应 Skill；也可在详情页获取输入模板和执行方式。" : "Start with the task, open the matching Skill, and use its input template and execution guide."}</p>

--- a/src/components/i18n/LocaleSelect.astro
+++ b/src/components/i18n/LocaleSelect.astro
@@ -139,7 +139,7 @@ const getFallbackPath = (lang: string) => {
     color: var(--color-main);
     background: transparent;
     border: 2px solid transparent;
-    border-radius: 4px;
+    border-radius: var(--radius-sm);
     cursor: pointer;
     transition: 0.2s ease-out;
   }
@@ -170,7 +170,7 @@ const getFallbackPath = (lang: string) => {
     padding: 4px;
     background: var(--color-base);
     border: 1px solid color-mix(in srgb, var(--color-theme) 25%, transparent);
-    border-radius: 6px;
+    border-radius: var(--radius-sm);
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
     z-index: 100;
   }
@@ -186,7 +186,7 @@ const getFallbackPath = (lang: string) => {
     font-weight: 600;
     color: var(--color-main);
     text-decoration: none;
-    border-radius: 4px;
+    border-radius: var(--radius-sm);
     transition: 0.15s ease-out;
   }
   .locale-panel a:hover {

--- a/src/components/prompts/AIOutputNotice.astro
+++ b/src/components/prompts/AIOutputNotice.astro
@@ -13,7 +13,7 @@ const items = lang === "zh-cn"
 </aside>
 
 <style>
-  .ai-notice { margin-block-end: 2.5rem; padding: 1.35rem 1.5rem; border: 1px solid color-mix(in srgb, var(--color-theme) 28%, transparent); border-radius: 20px; background: color-mix(in srgb, var(--color-theme) 5%, white); }
+  .ai-notice { margin-block-end: 2.5rem; padding: 1.35rem 1.5rem; border: 1px solid color-mix(in srgb, var(--color-theme) 28%, transparent); border-radius: var(--radius-lg); background: color-mix(in srgb, var(--color-theme) 5%, white); }
   h2 { margin: 0; font-size: 1.3rem; }
   ul { margin: .8rem 0 0; padding-left: 1.25rem; color: var(--color-text-secondary); line-height: 1.7; }
 </style>

--- a/src/config/guild.config.ts
+++ b/src/config/guild.config.ts
@@ -34,7 +34,7 @@ export const guildConfigZhCn: GuildConfig = {
       id: 'api-testing',
       title: '接口自动化测试',
       description: '学习如何使用各种框架进行 API 自动化测试',
-      icon: '🔌',
+      icon: 'power',
       frameworks: [
         {
           id: 'postman',
@@ -92,7 +92,7 @@ export const guildConfigZhCn: GuildConfig = {
       id: 'ui-testing',
       title: 'UI 自动化测试',
       description: '学习如何进行 Web UI 自动化测试',
-      icon: '🖥️',
+      icon: 'desktop_windows',
       frameworks: [
         {
           id: 'playwright',
@@ -120,7 +120,7 @@ export const guildConfigZhCn: GuildConfig = {
       id: 'performance-testing',
       title: '性能测试',
       description: '学习如何进行性能测试和压力测试',
-      icon: '⚡',
+      icon: 'bolt',
       frameworks: [
         {
           id: 'k6',
@@ -154,7 +154,7 @@ export const guildConfigEn: GuildConfig = {
       id: 'api-testing',
       title: 'API Automation Testing',
       description: 'Learn how to perform API automation testing with various frameworks',
-      icon: '🔌',
+      icon: 'power',
       frameworks: [
         {
           id: 'postman',
@@ -212,7 +212,7 @@ export const guildConfigEn: GuildConfig = {
       id: 'ui-testing',
       title: 'UI Automation Testing',
       description: 'Learn how to perform Web UI automation testing',
-      icon: '🖥️',
+      icon: 'desktop_windows',
       frameworks: [
         {
           id: 'playwright',
@@ -240,7 +240,7 @@ export const guildConfigEn: GuildConfig = {
       id: 'performance-testing',
       title: 'Performance Testing',
       description: 'Learn how to perform performance and load testing',
-      icon: '⚡',
+      icon: 'bolt',
       frameworks: [
         {
           id: 'k6',

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -418,6 +418,12 @@ export const HOME_EXPLORE_CARDS: Record<
       title: "Projects",
       desc: "开源与作品",
     },
+    {
+      key: "blog",
+      path: "/blog",
+      title: "博客",
+      desc: "文章与实践笔记",
+    },
   ],
   en: [
     {

--- a/src/layouts/Article.astro
+++ b/src/layouts/Article.astro
@@ -131,7 +131,7 @@ const {
     }
 
     img {
-      border-radius: 4px;
+      border-radius: var(--radius-sm);
       background-color: color-mix(in srgb, var(--color-main) 10%, transparent);
     }
 
@@ -160,7 +160,7 @@ const {
     right: 0.5em;
     background: rgba(255,255,255,0.12);
     border: 1px solid rgba(255,255,255,0.2);
-    border-radius: 4px;
+    border-radius: var(--radius-sm);
     color: rgba(255,255,255,0.7);
     cursor: pointer;
     font-size: 0.7rem;

--- a/src/layouts/Docs.astro
+++ b/src/layouts/Docs.astro
@@ -163,14 +163,14 @@ const rightTocLabel = tocLabel ?? (locale === "zh-cn" ? "本页目录" : "On thi
   .docs-content :global(code) {
     font-size: 0.9em;
     padding: 0.15em 0.4em;
-    border-radius: 6px;
+    border-radius: var(--radius-sm);
     background: color-mix(in srgb, var(--color-theme) 10%, transparent);
     border: 1px solid color-mix(in srgb, var(--color-theme) 22%, transparent);
   }
   .docs-content :global(pre) {
     overflow-x: auto;
     padding: var(--sp-m);
-    border-radius: 10px;
+    border-radius: var(--radius-sm);
     background: color-mix(in srgb, var(--color-main) 8%, var(--color-base));
     border: 1px solid color-mix(in srgb, var(--color-theme) 15%, transparent);
     margin-block: 1em 0;

--- a/src/pages/[lang]/AIWiki/[...slug].astro
+++ b/src/pages/[lang]/AIWiki/[...slug].astro
@@ -159,19 +159,19 @@ const structuredData = {
 
 <style>
   :global(.docs-sidebar-wrap) {
-    border-radius: 14px;
+    border-radius: var(--radius-md);
     overflow: hidden;
   }
 
   :global(.docs-sidebar) {
-    border-radius: 14px;
+    border-radius: var(--radius-md);
     overflow: hidden;
   }
 
   :global(.docs-sidebar-inner) {
     border-inline-start: none !important;
     border: 1px solid color-mix(in srgb, var(--color-theme) 18%, transparent) !important;
-    border-radius: 14px !important;
+    border-radius: var(--radius-md) !important;
     overflow: hidden;
     box-shadow: 0 4px 18px color-mix(in srgb, var(--color-main) 8%, transparent);
   }

--- a/src/pages/[lang]/AIWiki/index.astro
+++ b/src/pages/[lang]/AIWiki/index.astro
@@ -118,19 +118,19 @@ const letterGroupCount = letterSections.length;
 
 <style>
   :global(.docs-sidebar-wrap) {
-    border-radius: 14px;
+    border-radius: var(--radius-md);
     overflow: hidden;
   }
 
   :global(.docs-sidebar) {
-    border-radius: 14px;
+    border-radius: var(--radius-md);
     overflow: hidden;
   }
 
   :global(.docs-sidebar-inner) {
     border-inline-start: none !important;
     border: 1px solid color-mix(in srgb, var(--color-theme) 18%, transparent) !important;
-    border-radius: 14px !important;
+    border-radius: var(--radius-md) !important;
     overflow: hidden;
     box-shadow: 0 4px 18px color-mix(in srgb, var(--color-main) 8%, transparent);
   }
@@ -219,7 +219,7 @@ const letterGroupCount = letterSections.length;
     padding: var(--sp-m);
     padding-inline-start: var(--sp-m);
     border-inline-start: 3px solid color-mix(in srgb, var(--color-theme) 28%, transparent);
-    border-radius: 0 10px 10px 0;
+    border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
     background: color-mix(in srgb, var(--color-main) 4%, var(--color-base));
     scroll-margin-block-start: 1.5rem;
   }

--- a/src/pages/[lang]/about.astro
+++ b/src/pages/[lang]/about.astro
@@ -218,7 +218,7 @@ export const getStaticPaths = () =>
     align-items: center;
     gap: 0.25em 0.5em;
     padding: var(--sp-m);
-    border-radius: 10px;
+    border-radius: var(--radius-sm);
     background: color-mix(in srgb, var(--color-theme) 8%, transparent);
     transition: background 0.2s ease;
   }

--- a/src/pages/[lang]/blog/[...id].astro
+++ b/src/pages/[lang]/blog/[...id].astro
@@ -386,7 +386,7 @@ for (const item of candidates.sort((a, b) => b.score - a.score || a.label.locale
     width: 100%;
     aspect-ratio: 16 / 7.2;
     overflow: hidden;
-    border-radius: 20px;
+    border-radius: var(--radius-lg);
     margin-block-end: var(--sp-m);
     box-shadow: 0 4px 20px rgba(0,0,0,0.12);
   }
@@ -451,7 +451,7 @@ for (const item of candidates.sort((a, b) => b.score - a.score || a.label.locale
     background-color: var(--color-theme);
     color: white;
     padding: 0.35rem 0.75rem;
-    border-radius: 4px;
+    border-radius: var(--radius-sm);
     font-size: 0.875rem;
     text-decoration: none;
     transition: opacity 0.2s ease, transform 0.2s ease;
@@ -472,7 +472,7 @@ for (const item of candidates.sort((a, b) => b.score - a.score || a.label.locale
     margin: 1.25rem 0 1rem;
     padding: 0.9rem 1rem;
     border: 1px solid color-mix(in srgb, var(--color-theme) 30%, transparent);
-    border-radius: 14px;
+    border-radius: var(--radius-md);
     background: color-mix(in srgb, var(--color-theme) 8%, transparent);
   }
   .blog-related-terms h2 {
@@ -574,7 +574,7 @@ for (const item of candidates.sort((a, b) => b.score - a.score || a.label.locale
     font-family: ui-monospace, "Cascadia Code", "Source Code Pro", Menlo, Consolas, monospace;
     font-size: 0.9em;
     padding: 0.15em 0.4em;
-    border-radius: 4px;
+    border-radius: var(--radius-sm);
     background: color-mix(in srgb, var(--color-main) 12%, transparent);
     border: 1px solid color-mix(in srgb, var(--color-theme) 15%, transparent);
   }

--- a/src/pages/[lang]/blog/index.astro
+++ b/src/pages/[lang]/blog/index.astro
@@ -267,7 +267,7 @@ export const getStaticPaths = () =>
     display: inline-flex;
     align-items: center;
     padding: 0.38rem 0.95rem;
-    border-radius: 10px;
+    border-radius: var(--radius-sm);
     background: color-mix(in srgb, var(--color-theme) 12%, transparent);
     border: 1px solid color-mix(in srgb, var(--color-theme) 35%, transparent);
     color: var(--color-theme);

--- a/src/pages/[lang]/copyright.astro
+++ b/src/pages/[lang]/copyright.astro
@@ -35,15 +35,15 @@ export const getStaticPaths = () =>
 
     <h2>{locale === "zh-cn" ? "许可协议概要" : "License Summary"}</h2>
     <ul class="license-list">
-      <li><strong>{locale === "zh-cn" ? "署名" : "Attribution"}</strong> — {locale === "zh-cn" ? "您必须给出适当的署名，提供指向本许可协议的链接，同时说明是否对原始作品作了修改。" : "You must give appropriate credit, provide a link to the license, and indicate if changes were made."}</li>
-      <li><strong>{locale === "zh-cn" ? "非商业性使用" : "NonCommercial"}</strong> — {locale === "zh-cn" ? "您不得将本作品用于商业目的。" : "You may not use the material for commercial purposes."}</li>
-      <li><strong>{locale === "zh-cn" ? "相同方式共享" : "ShareAlike"}</strong> — {locale === "zh-cn" ? "如果您基于本作品进行了演绎，您必须基于与原先许可协议相同的许可协议分发您的作品。" : "If you remix, transform, or build upon the material, you must distribute your contributions under the same license as the original."}</li>
+      <li><strong>{locale === "zh-cn" ? "署名" : "Attribution"}</strong>: {locale === "zh-cn" ? "您必须给出适当的署名，提供指向本许可协议的链接，同时说明是否对原始作品作了修改。" : "You must give appropriate credit, provide a link to the license, and indicate if changes were made."}</li>
+      <li><strong>{locale === "zh-cn" ? "非商业性使用" : "NonCommercial"}</strong>: {locale === "zh-cn" ? "您不得将本作品用于商业目的。" : "You may not use the material for commercial purposes."}</li>
+      <li><strong>{locale === "zh-cn" ? "相同方式共享" : "ShareAlike"}</strong>: {locale === "zh-cn" ? "如果您基于本作品进行了演绎，您必须基于与原先许可协议相同的许可协议分发您的作品。" : "If you remix, transform, or build upon the material, you must distribute your contributions under the same license as the original."}</li>
     </ul>
 
     <h2>{locale === "zh-cn" ? freeToZh : freeToEn}</h2>
     <ul>
-      <li><strong>{locale === "zh-cn" ? "共享" : "Share"}</strong> — {locale === "zh-cn" ? "在任何媒介以任何形式复制、发行本作品" : "copy and redistribute the material in any medium or format"}</li>
-      <li><strong>{locale === "zh-cn" ? "演绎" : "Adapt"}</strong> — {locale === "zh-cn" ? "修改、转换或以本作品为基础进行创作" : "remix, transform, and build upon the material"}</li>
+      <li><strong>{locale === "zh-cn" ? "共享" : "Share"}</strong>: {locale === "zh-cn" ? "在任何媒介以任何形式复制、发行本作品" : "copy and redistribute the material in any medium or format"}</li>
+      <li><strong>{locale === "zh-cn" ? "演绎" : "Adapt"}</strong>: {locale === "zh-cn" ? "修改、转换或以本作品为基础进行创作" : "remix, transform, and build upon the material"}</li>
       <li>{locale === "zh-cn" ? "只要您遵守许可协议条款，许可人就无法收回您的这些权利。" : "The licensor cannot revoke these freedoms as long as you follow the license terms."}</li>
     </ul>
 

--- a/src/pages/[lang]/guild/[...slug].astro
+++ b/src/pages/[lang]/guild/[...slug].astro
@@ -337,7 +337,7 @@ for (const item of candidates.sort((a, b) => b.score - a.score || a.label.locale
     padding: var(--sp-m);
     margin-block-end: var(--sp-l);
     background: color-mix(in srgb, var(--color-theme) 8%, transparent);
-    border-radius: 10px;
+    border-radius: var(--radius-sm);
     border: 1px solid color-mix(in srgb, var(--color-theme) 20%, transparent);
   }
 
@@ -372,8 +372,8 @@ for (const item of candidates.sort((a, b) => b.score - a.score || a.label.locale
   }
 
   .difficulty-badge--intermediate {
-    background: color-mix(in srgb, var(--color-accent) 15%, transparent);
-    color: var(--color-accent);
+    background: color-mix(in srgb, var(--color-theme) 15%, transparent);
+    color: var(--color-theme);
   }
 
   .difficulty-badge--advanced {
@@ -416,7 +416,7 @@ for (const item of candidates.sort((a, b) => b.score - a.score || a.label.locale
     margin: 1.25rem 0 1rem;
     padding: 0.9rem 1rem;
     border: 1px solid color-mix(in srgb, var(--color-theme) 30%, transparent);
-    border-radius: 14px;
+    border-radius: var(--radius-md);
     background: color-mix(in srgb, var(--color-theme) 8%, transparent);
     max-inline-size: 68ch;
   }
@@ -494,7 +494,7 @@ for (const item of candidates.sort((a, b) => b.score - a.score || a.label.locale
     padding: var(--sp-m);
     background: var(--color-surface);
     border: 1px solid var(--color-border);
-    border-radius: 10px;
+    border-radius: var(--radius-sm);
     text-decoration: none;
     transition: var(--transition-base);
   }

--- a/src/pages/[lang]/guild/[testType]/[framework]/index.astro
+++ b/src/pages/[lang]/guild/[testType]/[framework]/index.astro
@@ -91,7 +91,7 @@ const diffLabel = locale === "zh-cn"
 
 const richDesc = locale === "zh-cn"
   ? `${frameworkConfig.description}。本专区提供 ${frameworkEntries.length} 篇系统化教程，覆盖从环境搭建到 CI/CD 集成的完整学习路径，适合${diffLabel}开发者和测试工程师快速上手 ${testTypeConfig.title}。`
-  : `${frameworkConfig.description}. This section offers ${frameworkEntries.length} structured tutorials covering environment setup through CI/CD integration — a complete ${diffLabel} learning path for ${testTypeConfig.title}.`;
+  : `${frameworkConfig.description}. This section offers ${frameworkEntries.length} structured tutorials covering environment setup through CI/CD integration, a complete ${diffLabel} learning path for ${testTypeConfig.title}.`;
 ---
 
 <Base title={pageTitle} description={metaDescription} contentWide={true}>
@@ -106,7 +106,10 @@ const richDesc = locale === "zh-cn"
         )}
         <div class="fw-hero__info">
           <div class="fw-hero__badges">
-            <span class="fw-badge fw-badge--type">{testTypeConfig.icon} {testTypeConfig.title}</span>
+            <span class="fw-badge fw-badge--type">
+              <span class="material-icons-sharp" aria-hidden="true">{testTypeConfig.icon}</span>
+              {testTypeConfig.title}
+            </span>
             {frameworkConfig.difficulty && (
               <span class={`fw-badge fw-badge--diff fw-badge--${frameworkConfig.difficulty}`}>
                 {locale === "zh-cn"
@@ -176,7 +179,8 @@ const richDesc = locale === "zh-cn"
       <div class="lp-header">
         <div class="lp-header__left">
           <h2 class="learning-path-title">
-            {locale === "zh-cn" ? "📖 学习路径" : "📖 Learning Path"}
+            <span class="material-icons-sharp" aria-hidden="true">menu_book</span>
+            {locale === "zh-cn" ? "学习路径" : "Learning Path"}
           </h2>
           <span class="lp-count">{frameworkEntries.length} {locale === "zh-cn" ? "篇" : "articles"}</span>
         </div>
@@ -266,7 +270,7 @@ const richDesc = locale === "zh-cn"
   .fw-hero {
     background: var(--color-surface);
     border: 1px solid var(--color-border);
-    border-radius: 16px;
+    border-radius: var(--radius-md);
     padding: 1.75rem;
     display: flex;
     flex-direction: column;
@@ -625,7 +629,7 @@ const richDesc = locale === "zh-cn"
 
   .article-difficulty {
     padding: 0.18em 0.6em;
-    border-radius: 5px;
+    border-radius: var(--radius-sm);
     font-weight: 600;
     font-size: 0.72rem;
   }

--- a/src/pages/[lang]/guild/[testType]/index.astro
+++ b/src/pages/[lang]/guild/[testType]/index.astro
@@ -128,7 +128,7 @@ const metaDescription = testTypeConfig.description;
     padding: 1.5rem;
     background: var(--color-surface);
     border: 1px solid var(--color-border);
-    border-radius: 16px;
+    border-radius: var(--radius-md);
   }
 
   .tt-header__icon {
@@ -213,7 +213,7 @@ const metaDescription = testTypeConfig.description;
     width: 32px;
     height: 32px;
     object-fit: contain;
-    border-radius: 6px;
+    border-radius: var(--radius-sm);
   }
 
   .fw-card__icon-fb {
@@ -227,7 +227,7 @@ const metaDescription = testTypeConfig.description;
     color: color-mix(in srgb, var(--color-main) 50%, transparent);
     background: color-mix(in srgb, var(--color-main) 8%, transparent);
     padding: 0.15em 0.5em;
-    border-radius: 4px;
+    border-radius: var(--radius-sm);
     white-space: nowrap;
   }
 

--- a/src/pages/[lang]/index.astro
+++ b/src/pages/[lang]/index.astro
@@ -44,7 +44,7 @@ const allPosts = (await getCollection("blog")).filter(
 
 const latestPosts = [...allPosts]
   .sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf())
-  .slice(0, 6);
+  .slice(0, 5);
 
 const tagCounts = allPosts
   .flatMap((post) => post.data.tags || [])
@@ -154,47 +154,11 @@ const exploreCards = HOME_EXPLORE_CARDS[locale].map((card) => ({
   href: getRelativeLocaleUrl(locale, card.path),
 }));
 
-const primaryEntries = [
-  {
-    key: "blog",
-    href: getRelativeLocaleUrl(locale, "/blog"),
-    eyebrow: locale === "zh-cn" ? "长期文章" : "Long-form writing",
-    title: locale === "zh-cn" ? "博客" : "Blog",
-    desc:
-      locale === "zh-cn"
-        ? "阅读软件测试、自动化、AI 工程和个人实践总结。"
-        : "Read software testing, automation, AI engineering, and personal practice notes.",
-  },
-  {
-    key: "wiki",
-    href:
-      locale === "zh-cn"
-        ? getRelativeLocaleUrl(locale, "/wiki")
-        : getRelativeLocaleUrl(locale, "/AIWiki"),
-    eyebrow: locale === "zh-cn" ? "系统知识" : "Reference",
-    title: locale === "zh-cn" ? "Wiki / AI 百科" : "Wiki / AI Wiki",
-    desc:
-      locale === "zh-cn"
-        ? "查询测试概念、AI 术语和工程实践词条。"
-        : "Look up testing concepts, AI terms, and engineering references.",
-  },
-  {
-    key: "qa-tools",
-    href: getRelativeLocaleUrl(locale, "/prompts"),
-    eyebrow: locale === "zh-cn" ? "QA 工具内容" : "QA tools",
-    title: locale === "zh-cn" ? "提示词、工作流与技能库" : "Prompts, workflows, and skills",
-    desc:
-      locale === "zh-cn"
-        ? "进入可复用的测试提示词、流程和 QA Skills。"
-        : "Use reusable testing prompts, workflows, and QA skills.",
-  },
-];
-
-/* …projects 羊皮纸 → guild 白 → wiki 羊皮纸 → aiwiki 白 → tags 羊皮纸
-   若无 wiki：guild 白 → aiwiki 羊皮纸 → tags 白 */
-const bandWiki = "parchment" as const;
-const bandAiWiki = showWiki ? ("white" as const) : ("parchment" as const);
-const bandTags = showWiki ? ("parchment" as const) : ("white" as const);
+/* …projects 冷灰 → guild 白 → wiki 冷灰 → aiwiki 白 → tags 冷灰
+   若无 wiki：guild 白 → aiwiki 冷灰 → tags 白 */
+const bandWiki = "muted" as const;
+const bandAiWiki = showWiki ? ("white" as const) : ("muted" as const);
+const bandTags = showWiki ? ("muted" as const) : ("white" as const);
 
 export const getStaticPaths = () =>
   Object.keys(LOCALES).map((lang) => ({
@@ -241,7 +205,7 @@ const homePageSchema = {
   extraStructuredData={[homePageSchema]}
 >
   <div class="home-page">
-    <section class="home-band home-band--white home-apple-hero">
+    <section class="home-band home-band--white home-hero">
       <div class="home-inner">
         <h1 class="home-hero__title">{t(HOME_HERO_TITLE)}</h1>
         <p class="home-hero__subtitle">{t(HOME_HERO_SUBTITLE)}</p>
@@ -261,54 +225,6 @@ const homePageSchema = {
             {t(HOME_CTA_WIKI)}
           </a>
         </div>
-        <ul
-          class="home-primary-entries"
-          role="list"
-          aria-label={locale === "zh-cn" ? "主要内容入口" : "Primary content entries"}
-        >
-          {primaryEntries.map((entry) => (
-            <li>
-              {entry.key === "qa-tools" ? (
-                <div class="home-primary-entry home-primary-entry--act">
-                  <span class="home-primary-entry__eyebrow">{entry.eyebrow}</span>
-                  <span class="home-primary-entry__title">{entry.title}</span>
-                  <span class="home-primary-entry__desc">{entry.desc}</span>
-                  <span class="home-primary-entry__actions">
-                    <a href={getRelativeLocaleUrl(locale, "/qaskills/")}>Skills →</a>
-                    <a href={getRelativeLocaleUrl(locale, "/prompts/")}>Prompts →</a>
-                  </span>
-                </div>
-              ) : (
-                <a class={`home-primary-entry home-primary-entry--${entry.key}`} href={entry.href}>
-                  <span class="home-primary-entry__eyebrow">{entry.eyebrow}</span>
-                  <span class="home-primary-entry__title">{entry.title}</span>
-                  <span class="home-primary-entry__desc">{entry.desc}</span>
-                </a>
-              )}
-            </li>
-          ))}
-        </ul>
-        <div class="home-hero-console" aria-label={locale === "zh-cn" ? "推荐资源入口" : "Featured resource entries"}>
-          <div class="console-topbar">
-            <span></span>
-            <span></span>
-            <span></span>
-          </div>
-          <div class="console-grid">
-            <a class="console-card console-card--primary" href={locale === "zh-cn" ? getRelativeLocaleUrl(locale, "/wiki/") : getRelativeLocaleUrl(locale, "/AIWiki/")}>
-              <span>{locale === "zh-cn" ? "知识库" : "Knowledge"}</span>
-              <strong>{locale === "zh-cn" ? "测试百科" : "QA Wiki"}</strong>
-            </a>
-            <a class="console-card" href={getRelativeLocaleUrl(locale, "/qaskills/")}>
-              <span>{locale === "zh-cn" ? "自动化" : "Automation"}</span>
-              <strong>{locale === "zh-cn" ? "技能路径" : "Skill Paths"}</strong>
-            </a>
-            <a class="console-card" href={getRelativeLocaleUrl(locale, "/prompts/")}>
-              <span>{locale === "zh-cn" ? "AI 测试" : "AI Testing"}</span>
-              <strong>{locale === "zh-cn" ? "提示词库" : "Prompt Library"}</strong>
-            </a>
-          </div>
-        </div>
       </div>
     </section>
 
@@ -316,7 +232,7 @@ const homePageSchema = {
     <CoreCapabilities locale={locale} />
     <HomeProofAndCases locale={locale} />
 
-    <section class="home-band home-band--parchment" aria-labelledby="home-explore-title">
+    <section class="home-band home-band--muted" aria-labelledby="home-explore-title">
       <div class="home-inner">
         <h2 id="home-explore-title" class="home-band__title">{t(HOME_EXPLORE_TITLE)}</h2>
         <p class="home-band__subtitle">{t(HOME_EXPLORE_SUBTITLE)}</p>
@@ -340,7 +256,7 @@ const homePageSchema = {
     >
       <div class="home-inner">
         <h2 id="home-latest-title" class="home-band__title">{t(HOME_LATEST_POSTS)}</h2>
-        <ul class="home-grid" role="list">
+        <ul class="home-post-list" role="list">
           {latestPosts.map((post) => {
             const idParts = post.id.split("/").slice(1);
             const postUrl = `/${locale}/blog/${idParts.join("/").toLowerCase()}/`;
@@ -350,18 +266,20 @@ const homePageSchema = {
             );
             return (
               <li>
-                <a class="home-card" href={postUrl}>
+                <a class="home-post-item" href={postUrl}>
                   <time
-                    class="home-card__meta"
+                    class="home-post-item__date"
                     datetime={post.data.date.toISOString()}
                   >
                     {dateStr}
                   </time>
-                  <h3 class="home-card__title">{post.data.title}</h3>
-                  {post.data.description && (
-                    <p class="home-card__desc">{post.data.description}</p>
-                  )}
-                  <span class="home-card__more">{t(HOME_EXPLORE_MORE)}</span>
+                  <div class="home-post-item__body">
+                    <h3 class="home-post-item__title">{post.data.title}</h3>
+                    {post.data.description && (
+                      <p class="home-post-item__desc">{post.data.description}</p>
+                    )}
+                  </div>
+                  <span class="home-post-item__arrow" aria-hidden="true">→</span>
                 </a>
               </li>
             );
@@ -381,7 +299,7 @@ const homePageSchema = {
     <GoogleAdThin />
 
     <section
-      class="home-band home-band--parchment home-prompts"
+      class="home-band home-band--muted home-prompts"
       aria-labelledby="home-prompts-title"
     >
       <div class="home-inner">
@@ -490,25 +408,24 @@ const homePageSchema = {
     </section>
 
     <section
-      class="home-band home-band--parchment home-projects"
+      class="home-band home-band--muted home-projects"
       aria-labelledby="home-projects-title"
     >
       <div class="home-inner">
         <h2 id="home-projects-title" class="home-band__title">
           {t(HOME_PROJECTS_TITLE)}
         </h2>
-        <ul class="home-grid" role="list">
+        <ul class="home-project-list" role="list">
           {featuredProjects.map((proj) => (
             <li>
               <a
-                class="home-card"
+                class="home-project-item"
                 href={proj.url}
                 target="_blank"
                 rel="noopener noreferrer"
               >
-                <h3 class="home-card__title">{t(proj.name)}</h3>
-                <p class="home-card__desc">{t(proj.description)}</p>
-                <span class="home-card__more">{t(HOME_EXPLORE_MORE)}</span>
+                <h3 class="home-project-item__title">{t(proj.name)}</h3>
+                <p class="home-project-item__desc">{t(proj.description)}</p>
               </a>
             </li>
           ))}
@@ -642,21 +559,9 @@ const homePageSchema = {
     padding-block-end: 0;
   }
 
-  .home-page {
-    background: #f5f5f7;
-  }
-
   :global(.home-band) {
     width: 100%;
     padding-block: 72px;
-  }
-
-  :global(.home-band--white) {
-    background: #ffffff;
-  }
-
-  :global(.home-band--parchment) {
-    background: #f5f5f7;
   }
 
   :global(.home-inner) {
@@ -688,66 +593,6 @@ const homePageSchema = {
     gap: 12px;
     justify-content: center;
     flex-wrap: wrap;
-  }
-
-  .home-primary-entries {
-    list-style: none;
-    margin: 36px 0 0;
-    padding: 0;
-    display: grid;
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-    gap: 14px;
-    text-align: start;
-  }
-
-  .home-primary-entry {
-    display: grid;
-    gap: 8px;
-    min-height: 156px;
-    padding: 22px;
-    border: 1px solid color-mix(in srgb, var(--color-theme) 16%, #d8d8dc);
-    border-radius: 16px;
-    color: #1d1d1f;
-    background: #fafafc;
-    text-decoration: none;
-  }
-
-  .home-primary-entry:hover,
-  .home-primary-entry:focus-visible {
-    border-color: var(--color-theme);
-    background: color-mix(in srgb, var(--color-theme) 6%, #ffffff);
-  }
-
-  .home-primary-entry__eyebrow {
-    font-size: 12px;
-    line-height: 1.3;
-    color: var(--color-theme);
-    font-weight: 700;
-  }
-
-  .home-primary-entry__title {
-    font-size: 19px;
-    line-height: 1.25;
-    font-weight: 700;
-  }
-
-  .home-primary-entry__desc {
-    font-size: 14px;
-    line-height: 1.5;
-    color: #6e6e73;
-  }
-
-  .home-primary-entry__actions {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 12px;
-    align-self: end;
-  }
-
-  .home-primary-entry__actions a {
-    color: var(--color-theme);
-    font-weight: 700;
-    text-decoration: none;
   }
 
   :global(.home-band__title) {
@@ -866,15 +711,6 @@ const homePageSchema = {
     color: var(--color-theme);
   }
 
-  .home-latest-posts .home-grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-
-  .home-latest-posts .home-card {
-    min-height: 136px;
-    padding: 20px;
-  }
-
   .home-chip-cloud {
     list-style: none;
     margin: 28px 0 0;
@@ -922,8 +758,6 @@ const homePageSchema = {
       width: min(980px, calc(100% - 32px));
     }
 
-    .home-primary-entries,
-    .home-latest-posts .home-grid,
     .home-grid {
       grid-template-columns: 1fr;
     }
@@ -933,7 +767,7 @@ const homePageSchema = {
   .home-page {
     background:
       linear-gradient(rgba(79, 70, 229, 0.035) 1px, transparent 1px),
-      linear-gradient(90deg, rgba(20, 184, 166, 0.035) 1px, transparent 1px),
+      linear-gradient(90deg, rgba(79, 70, 229, 0.035) 1px, transparent 1px),
       #f8fafc;
     background-size: 42px 42px, 42px 42px, auto;
   }
@@ -945,7 +779,7 @@ const homePageSchema = {
   }
 
   :global(.home-band--white),
-  :global(.home-band--parchment) {
+  :global(.home-band--muted) {
     background: transparent;
   }
 
@@ -964,11 +798,11 @@ const homePageSchema = {
     width: min(1120px, calc(100% - 48px));
   }
 
-  .home-apple-hero {
-    min-height: 640px;
+  .home-hero {
+    min-height: 380px;
     display: grid;
     align-items: center;
-    padding-block: 96px 72px;
+    padding-block: 80px 64px;
     background: var(--gradient-hero);
   }
 
@@ -990,7 +824,7 @@ const homePageSchema = {
     height: 5px;
     margin: 22px auto 0;
     border-radius: 999px;
-    background: linear-gradient(90deg, var(--color-theme), var(--color-accent));
+    background: linear-gradient(90deg, var(--color-theme), var(--color-theme-light));
   }
 
   .home-hero__subtitle {
@@ -1015,7 +849,7 @@ const homePageSchema = {
   }
 
   .pill-cta--primary {
-    background: linear-gradient(135deg, var(--color-theme), color-mix(in srgb, var(--color-theme) 76%, var(--color-accent)));
+    background: linear-gradient(135deg, var(--color-theme), color-mix(in srgb, var(--color-theme) 76%, var(--color-theme-light)));
     color: white;
     border: 1px solid color-mix(in srgb, var(--color-theme) 24%, transparent);
     box-shadow: 0 18px 40px rgba(79, 70, 229, 0.22);
@@ -1031,96 +865,6 @@ const homePageSchema = {
   .pill-cta:hover,
   .pill-cta:focus-visible {
     transform: translateY(-2px);
-  }
-
-  .home-hero-console {
-    max-width: 780px;
-    margin: 42px auto 0;
-    padding: 14px;
-    border: 1px solid rgba(148, 163, 184, 0.24);
-    border-radius: 24px;
-    background: rgba(255, 255, 255, 0.78);
-    box-shadow: var(--shadow-lg);
-    backdrop-filter: blur(22px);
-    text-align: start;
-  }
-
-  .console-topbar {
-    display: flex;
-    gap: 7px;
-    padding: 6px 8px 14px;
-  }
-
-  .console-topbar span {
-    width: 10px;
-    height: 10px;
-    border-radius: 999px;
-    background: #cbd5e1;
-  }
-
-  .console-topbar span:nth-child(1) {
-    background: #fb7185;
-  }
-
-  .console-topbar span:nth-child(2) {
-    background: #fbbf24;
-  }
-
-  .console-topbar span:nth-child(3) {
-    background: #34d399;
-  }
-
-  .console-grid {
-    display: grid;
-    grid-template-columns: 1.2fr 1fr 1fr;
-    gap: 12px;
-  }
-
-  .console-card {
-    display: block;
-    min-height: 120px;
-    padding: 18px;
-    border: 1px solid rgba(148, 163, 184, 0.24);
-    border-radius: 18px;
-    background: linear-gradient(180deg, rgba(255, 255, 255, 0.96), rgba(248, 250, 252, 0.92));
-    color: inherit;
-    text-decoration: none;
-    transition: transform 180ms ease, border-color 180ms ease, box-shadow 180ms ease;
-  }
-
-  .console-card:hover,
-  .console-card:focus-visible {
-    transform: translateY(-2px);
-    border-color: color-mix(in srgb, var(--color-theme) 42%, transparent);
-    box-shadow: var(--shadow-md);
-  }
-
-  .console-card span {
-    display: block;
-    margin-bottom: 22px;
-    color: var(--color-text-tertiary);
-    font-size: 12px;
-    font-weight: 800;
-  }
-
-  .console-card strong {
-    display: block;
-    color: var(--color-main);
-    font-family: var(--font-heading);
-    font-size: 20px;
-    line-height: 1.2;
-  }
-
-  .console-card--primary {
-    background:
-      linear-gradient(135deg, rgba(79, 70, 229, 0.95), rgba(20, 184, 166, 0.88));
-    color: white;
-    border-color: transparent;
-  }
-
-  .console-card--primary span,
-  .console-card--primary strong {
-    color: white;
   }
 
   :global(.home-band__title) {
@@ -1143,7 +887,7 @@ const homePageSchema = {
     min-height: 190px;
     padding: 24px;
     border: 1px solid rgba(148, 163, 184, 0.22);
-    border-radius: 20px;
+    border-radius: var(--radius-lg);
     background:
       linear-gradient(180deg, rgba(255, 255, 255, 0.92), rgba(248, 250, 252, 0.82));
     box-shadow: var(--shadow-sm);
@@ -1184,6 +928,132 @@ const homePageSchema = {
     font-weight: 800;
   }
 
+  /* 最新文章：纵向行列表，与卡片阵列错开布局 */
+  .home-post-list {
+    list-style: none;
+    margin: 28px 0 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    text-align: start;
+  }
+
+  .home-post-item {
+    display: flex;
+    align-items: center;
+    gap: 18px;
+    padding: 16px 20px;
+    border: 1px solid rgba(148, 163, 184, 0.22);
+    border-radius: var(--radius-md);
+    background: rgba(255, 255, 255, 0.86);
+    box-shadow: var(--shadow-sm);
+    color: inherit;
+    text-decoration: none;
+    transition:
+      transform 220ms ease,
+      border-color 220ms ease,
+      box-shadow 220ms ease;
+  }
+
+  .home-post-item:hover,
+  .home-post-item:focus-visible {
+    transform: translateY(-2px);
+    border-color: color-mix(in srgb, var(--color-theme) 32%, transparent);
+    box-shadow: var(--shadow-md);
+  }
+
+  .home-post-item__date {
+    flex: 0 0 auto;
+    min-width: 92px;
+    color: var(--color-text-tertiary);
+    font-size: 13px;
+  }
+
+  .home-post-item__body {
+    flex: 1;
+    min-width: 0;
+  }
+
+  .home-post-item__title {
+    margin: 0;
+    font-family: var(--font-heading);
+    font-size: 16px;
+    font-weight: 800;
+    line-height: 1.35;
+    color: var(--color-main);
+  }
+
+  .home-post-item__desc {
+    margin: 4px 0 0;
+    font-size: 14px;
+    line-height: 1.45;
+    color: var(--color-text-tertiary);
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+
+  .home-post-item__arrow {
+    flex: 0 0 auto;
+    color: var(--color-theme);
+    font-weight: 800;
+  }
+
+  /* 精选项目：紧凑行列表 */
+  .home-project-list {
+    list-style: none;
+    margin: 28px 0 0;
+    padding: 0;
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 10px;
+    text-align: start;
+  }
+
+  .home-project-item {
+    display: block;
+    padding: 16px 20px;
+    border: 1px solid rgba(148, 163, 184, 0.22);
+    border-radius: var(--radius-md);
+    background: rgba(255, 255, 255, 0.86);
+    box-shadow: var(--shadow-sm);
+    color: inherit;
+    text-decoration: none;
+    transition:
+      transform 220ms ease,
+      border-color 220ms ease,
+      box-shadow 220ms ease;
+  }
+
+  .home-project-item:hover,
+  .home-project-item:focus-visible {
+    transform: translateY(-2px);
+    border-color: color-mix(in srgb, var(--color-theme) 32%, transparent);
+    box-shadow: var(--shadow-md);
+  }
+
+  .home-project-item__title {
+    margin: 0;
+    font-family: var(--font-heading);
+    font-size: 15px;
+    font-weight: 800;
+    line-height: 1.35;
+    color: var(--color-main);
+  }
+
+  .home-project-item__desc {
+    margin: 4px 0 0;
+    font-size: 13px;
+    line-height: 1.5;
+    color: var(--color-text-tertiary);
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+
   .home-chip {
     border-color: rgba(148, 163, 184, 0.24);
     background: rgba(255, 255, 255, 0.78);
@@ -1204,7 +1074,7 @@ const homePageSchema = {
       padding-block: 58px;
     }
 
-    .home-apple-hero {
+    .home-hero {
       min-height: 0;
       padding-block: 72px 52px;
     }
@@ -1221,16 +1091,8 @@ const homePageSchema = {
       width: min(980px, calc(100% - 32px));
     }
 
-    .console-grid {
+    .home-project-list {
       grid-template-columns: 1fr;
-    }
-
-    .console-card {
-      min-height: 98px;
-    }
-
-    .console-card span {
-      margin-bottom: 12px;
     }
 
     :global(.home-band__title) {

--- a/src/pages/[lang]/links.astro
+++ b/src/pages/[lang]/links.astro
@@ -75,7 +75,7 @@ export const getStaticPaths = () =>
     display: flex;
     flex-direction: column;
     padding: var(--sp-m);
-    border-radius: 16px;
+    border-radius: var(--radius-md);
     background: color-mix(in srgb, var(--color-base) 96%, var(--color-main));
     border: 1px solid color-mix(in srgb, var(--color-theme) 14%, transparent);
     text-decoration: none;

--- a/src/pages/[lang]/projects/index.astro
+++ b/src/pages/[lang]/projects/index.astro
@@ -71,7 +71,7 @@ export const getStaticPaths = () =>
     display: flex;
     flex-direction: column;
     padding: var(--sp-m);
-    border-radius: 20px;
+    border-radius: var(--radius-lg);
     background: color-mix(in srgb, var(--color-base) 95%, var(--color-main));
     border: 1px solid color-mix(in srgb, var(--color-theme) 15%, transparent);
     text-decoration: none;
@@ -147,7 +147,7 @@ export const getStaticPaths = () =>
     padding: 0.2rem 0.6rem;
     background: color-mix(in srgb, var(--color-theme) 8%, transparent);
     color: var(--color-theme);
-    border-radius: 6px;
+    border-radius: var(--radius-sm);
     border: 1px solid color-mix(in srgb, var(--color-theme) 10%, transparent);
   }
 

--- a/src/pages/[lang]/prompts/[testingType].astro
+++ b/src/pages/[lang]/prompts/[testingType].astro
@@ -518,7 +518,7 @@ const sidebarLabel = lang === "zh-cn" ? "测试类型" : "Testing Types";
     color: var(--color-main);
     background: color-mix(in srgb, var(--color-main) 8%, var(--color-base));
     border: 1px solid color-mix(in srgb, var(--color-theme) 22%, transparent);
-    border-radius: 7px;
+    border-radius: var(--radius-sm);
     outline: none;
     box-sizing: border-box;
   }
@@ -564,7 +564,7 @@ const sidebarLabel = lang === "zh-cn" ? "测试类型" : "Testing Types";
     font-weight: 500;
     color: color-mix(in srgb, var(--color-main) 85%, transparent);
     text-decoration: none;
-    border-radius: 6px;
+    border-radius: var(--radius-sm);
     transition: background 0.15s ease, color 0.15s ease;
     line-height: 1.4;
   }
@@ -591,7 +591,7 @@ const sidebarLabel = lang === "zh-cn" ? "测试类型" : "Testing Types";
   .prompt-detail-header {
     margin-block-end: var(--sp-m);
     padding: var(--sp-m);
-    border-radius: 14px;
+    border-radius: var(--radius-md);
     border: 1px solid color-mix(in srgb, var(--color-theme) 20%, transparent);
     background: color-mix(in srgb, var(--color-theme) 5%, var(--color-base));
     border-inline-start: 4px solid var(--color-theme);
@@ -764,7 +764,7 @@ const sidebarLabel = lang === "zh-cn" ? "测试类型" : "Testing Types";
     font-family: ui-monospace, "Cascadia Code", Menlo, Consolas, monospace;
     font-size: 0.9em; color: var(--color-theme);
     background: color-mix(in srgb, var(--color-theme) 10%, transparent);
-    padding: 0.15em 0.4em; border-radius: 4px;
+    padding: 0.15em 0.4em; border-radius: var(--radius-sm);
   }
   .prompt-content :global(pre) {
     direction: ltr; padding: 1em 1.25em; border-radius: 8px;

--- a/src/pages/[lang]/prompts/index.astro
+++ b/src/pages/[lang]/prompts/index.astro
@@ -206,55 +206,55 @@ const itemListSchema = {
       <div class="flow-wrap">
         {([
           {
-            icon: "📝",
+            icon: "edit_note",
             slug: "requirements-analysis",
             label: lang === "zh-cn" ? "需求分析" : "Requirements Analysis",
             desc: lang === "zh-cn" ? "深度分析需求文档，设计全维度测试场景" : "Analyze requirements and design comprehensive test scenarios",
           },
           {
-            icon: "🎯",
+            icon: "track_changes",
             slug: "test-strategy",
             label: lang === "zh-cn" ? "测试策略" : "Test Strategy",
             desc: lang === "zh-cn" ? "制定整体测试策略和测试计划" : "Define overall test strategy and test plan",
           },
           {
-            icon: "✍️",
+            icon: "edit",
             slug: "test-case-writing",
             label: lang === "zh-cn" ? "测试用例编写" : "Test Case Writing",
             desc: lang === "zh-cn" ? "基于测试场景生成详细测试用例" : "Generate detailed test cases from test scenarios",
           },
           {
-            icon: "🔍",
+            icon: "search",
             slug: "functional-testing",
             label: lang === "zh-cn" ? "功能测试" : "Functional Testing",
             desc: lang === "zh-cn" ? "执行功能测试，确保功能完整性" : "Execute functional tests to ensure completeness",
           },
           {
-            icon: "🤖",
+            icon: "smart_toy",
             slug: "automation-testing",
             label: lang === "zh-cn" ? "自动化测试" : "Automation Testing",
             desc: lang === "zh-cn" ? "设计自动化测试脚本和框架" : "Design automation test scripts and frameworks",
           },
           {
-            icon: "⚡",
+            icon: "bolt",
             slug: "performance-testing",
             label: lang === "zh-cn" ? "性能测试" : "Performance Testing",
             desc: lang === "zh-cn" ? "设计性能测试场景和指标分析" : "Design performance test scenarios and metrics",
           },
           {
-            icon: "🔒",
+            icon: "lock",
             slug: "security-testing",
             label: lang === "zh-cn" ? "安全测试" : "Security Testing",
             desc: lang === "zh-cn" ? "检测安全漏洞和安全测试策略" : "Detect vulnerabilities and define security strategy",
           },
           {
-            icon: "🐛",
+            icon: "bug_report",
             slug: "bug-reporting",
             label: lang === "zh-cn" ? "缺陷上报" : "Bug Reporting",
             desc: lang === "zh-cn" ? "标准化缺陷报告和根因分析" : "Standardized bug reports and root cause analysis",
           },
           {
-            icon: "📊",
+            icon: "bar_chart",
             slug: "test-reporting",
             label: lang === "zh-cn" ? "测试报告" : "Test Reporting",
             desc: lang === "zh-cn" ? "生成测试执行报告和质量分析" : "Generate test execution reports and quality analysis",
@@ -265,7 +265,7 @@ const itemListSchema = {
               href={getRelativeLocaleUrl(lang, `/prompts/${step.slug}/`)}
               class="flow-node"
             >
-              <span class="flow-icon" aria-hidden="true">{step.icon}</span>
+              <span class="flow-icon material-icons-sharp" aria-hidden="true">{step.icon}</span>
               <span class="flow-label">{step.label}</span>
               <span class="flow-desc">{step.desc}</span>
             </a>
@@ -321,10 +321,10 @@ const itemListSchema = {
     gap: 2rem;
     padding: 2rem;
     border: 1px solid rgba(148, 163, 184, 0.22);
-    border-radius: 28px;
+    border-radius: var(--radius-lg);
     background:
       radial-gradient(circle at 18% 12%, rgba(79, 70, 229, 0.16), transparent 34%),
-      radial-gradient(circle at 92% 18%, rgba(20, 184, 166, 0.16), transparent 30%),
+      radial-gradient(circle at 92% 18%, rgba(67, 56, 202, 0.16), transparent 30%),
       rgba(255, 255, 255, 0.78);
     box-shadow: var(--shadow-md);
     overflow: hidden;
@@ -424,7 +424,7 @@ const itemListSchema = {
 
   .prompt-console {
     border: 1px solid rgba(148, 163, 184, 0.24);
-    border-radius: 22px;
+    border-radius: var(--radius-lg);
     background: rgba(255, 255, 255, 0.86);
     box-shadow: var(--shadow-lg);
     overflow: hidden;
@@ -446,7 +446,7 @@ const itemListSchema = {
   }
 
   .prompt-console-bar span:nth-child(2) {
-    background: rgba(20, 184, 166, 0.42);
+    background: rgba(129, 140, 248, 0.42);
   }
 
   .prompt-console-bar span:nth-child(3) {
@@ -463,8 +463,8 @@ const itemListSchema = {
     width: fit-content;
     border-radius: 999px;
     padding: 0.28rem 0.65rem;
-    background: rgba(20, 184, 166, 0.12);
-    color: var(--color-accent);
+    background: rgba(79, 70, 229, 0.12);
+    color: var(--color-theme);
     font-size: 0.78rem;
     font-weight: 800;
   }
@@ -490,7 +490,7 @@ const itemListSchema = {
   .prompt-lines span {
     height: 0.62rem;
     border-radius: 999px;
-    background: linear-gradient(90deg, rgba(79, 70, 229, 0.18), rgba(20, 184, 166, 0.12));
+    background: linear-gradient(90deg, rgba(79, 70, 229, 0.18), rgba(129, 140, 248, 0.12));
   }
 
   .prompt-lines span:nth-child(2) {
@@ -668,7 +668,7 @@ const itemListSchema = {
     align-items: center;
     gap: var(--sp-s);
     padding: var(--sp-m);
-    border-radius: 20px;
+    border-radius: var(--radius-lg);
     border: 1px solid rgba(148, 163, 184, 0.2);
     background: rgba(255, 255, 255, 0.76);
   }
@@ -684,7 +684,7 @@ const itemListSchema = {
     align-items: flex-start;
     gap: 0.4rem;
     padding: var(--sp-s) var(--sp-m);
-    border-radius: 16px;
+    border-radius: var(--radius-md);
     border: 1px solid rgba(148, 163, 184, 0.2);
     background: rgba(255, 255, 255, 0.78);
     text-decoration: none;
@@ -709,6 +709,7 @@ const itemListSchema = {
   .flow-icon {
     font-size: 1.75rem;
     line-height: 1;
+    color: var(--color-theme);
   }
 
   .flow-label {

--- a/src/pages/[lang]/prompts/workflows/[workflowType].astro
+++ b/src/pages/[lang]/prompts/workflows/[workflowType].astro
@@ -187,7 +187,7 @@ const howToSchema = {
   }
   .workflow-sidebar-inner {
     border-inline-start: 3px solid color-mix(in srgb, var(--color-theme) 35%, transparent);
-    border-radius: 0 10px 10px 0;
+    border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
     background: color-mix(in srgb, var(--color-base) 96%, var(--color-main));
   }
   .workflow-sidebar-toggle {
@@ -245,7 +245,7 @@ const howToSchema = {
     font-weight: 500;
     color: color-mix(in srgb, var(--color-main) 85%, transparent);
     text-decoration: none;
-    border-radius: 6px;
+    border-radius: var(--radius-sm);
     transition: background 0.15s ease, color 0.15s ease;
     line-height: 1.4;
   }
@@ -273,7 +273,7 @@ const howToSchema = {
     font-weight: 500;
     color: color-mix(in srgb, var(--color-main) 60%, transparent);
     text-decoration: none;
-    border-radius: 6px;
+    border-radius: var(--radius-sm);
     transition: color 0.15s ease;
   }
   .workflow-sidebar-back:hover {
@@ -323,7 +323,7 @@ const howToSchema = {
     font-family: ui-monospace, "Cascadia Code", Menlo, Consolas, monospace;
     font-size: 0.9em; color: var(--color-theme);
     background: color-mix(in srgb, var(--color-theme) 10%, transparent);
-    padding: 0.15em 0.4em; border-radius: 4px;
+    padding: 0.15em 0.4em; border-radius: var(--radius-sm);
   }
   .workflow-content :global(pre) {
     direction: ltr; padding: 1em 1.25em; border-radius: 8px;

--- a/src/pages/[lang]/qaskills/[skillSlug].astro
+++ b/src/pages/[lang]/qaskills/[skillSlug].astro
@@ -548,7 +548,7 @@ const tocHeadings = [
     min-width: 0;
   }
   .detail-header {
-    border-radius: 14px;
+    border-radius: var(--radius-md);
     border: 1px solid color-mix(in srgb, var(--color-theme) 22%, transparent);
     background: color-mix(in srgb, var(--color-theme) 6%, var(--color-base));
     padding: 0.95rem;
@@ -626,7 +626,7 @@ const tocHeadings = [
   .elevator-link {
     display: block;
     padding: 0.28rem 0.4rem;
-    border-radius: 6px;
+    border-radius: var(--radius-sm);
     border-left: 2px solid transparent;
     color: inherit;
     text-decoration: none;
@@ -680,7 +680,7 @@ const tocHeadings = [
   }
   .raw-wrap {
     border: 1px solid color-mix(in srgb, var(--color-main) 15%, transparent);
-    border-radius: 10px;
+    border-radius: var(--radius-sm);
     overflow: hidden;
     background: color-mix(in srgb, var(--color-main) 8%, var(--color-base));
   }
@@ -773,7 +773,7 @@ const tocHeadings = [
     align-items: center;
     justify-content: center;
     text-decoration: none;
-    border-radius: 9px;
+    border-radius: var(--radius-sm);
     padding: 0.4rem 0.75rem;
     font-weight: 700;
     font-size: 0.875rem;

--- a/src/pages/[lang]/qaskills/index.astro
+++ b/src/pages/[lang]/qaskills/index.astro
@@ -451,10 +451,10 @@ const displayNameOf = (skill: (typeof allSkills)[number]) =>
   }
   .hero {
     padding: 2rem;
-    border-radius: 28px;
+    border-radius: var(--radius-lg);
     background:
       radial-gradient(circle at 18% 12%, rgba(79, 70, 229, 0.16), transparent 34%),
-      radial-gradient(circle at 90% 18%, rgba(20, 184, 166, 0.16), transparent 30%),
+      radial-gradient(circle at 90% 18%, rgba(67, 56, 202, 0.16), transparent 30%),
       rgba(255, 255, 255, 0.78);
     border: 1px solid rgba(148, 163, 184, 0.22);
     box-shadow: var(--shadow-md);
@@ -517,14 +517,14 @@ const displayNameOf = (skill: (typeof allSkills)[number]) =>
     gap: 0.75rem;
     padding: 0.85rem;
     border: 1px solid rgba(148, 163, 184, 0.18);
-    border-radius: 22px;
+    border-radius: var(--radius-lg);
     background: rgba(255, 255, 255, 0.72);
     box-shadow: var(--shadow-sm);
   }
   .search-input {
     width: 100%;
     min-height: 48px;
-    border-radius: 16px;
+    border-radius: var(--radius-md);
     border: 1px solid rgba(148, 163, 184, 0.24);
     background: rgba(255, 255, 255, 0.88);
     padding: 0.65rem 0.95rem;
@@ -600,7 +600,7 @@ const displayNameOf = (skill: (typeof allSkills)[number]) =>
   .category-block {
     margin-top: 1rem;
     border: 1px solid rgba(148, 163, 184, 0.2);
-    border-radius: 20px;
+    border-radius: var(--radius-lg);
     background: rgba(255, 255, 255, 0.76);
     padding: 1rem;
     box-shadow: var(--shadow-sm);
@@ -639,7 +639,7 @@ const displayNameOf = (skill: (typeof allSkills)[number]) =>
     height: 100%;
     text-decoration: none;
     color: inherit;
-    border-radius: 16px;
+    border-radius: var(--radius-md);
     border: 1px solid rgba(148, 163, 184, 0.2);
     background: rgba(255, 255, 255, 0.78);
     padding: 0.85rem;

--- a/src/pages/[lang]/series/[series].astro
+++ b/src/pages/[lang]/series/[series].astro
@@ -125,7 +125,7 @@ const breadcrumbs = [
   .post-card {
     display: flex;
     flex-direction: column;
-    border-radius: 20px;
+    border-radius: var(--radius-lg);
     overflow: hidden;
     background: color-mix(in srgb, var(--color-base) 95%, var(--color-main));
     border: 1px solid color-mix(in srgb, var(--color-theme) 15%, transparent);
@@ -237,7 +237,7 @@ const breadcrumbs = [
     color: var(--color-theme);
     text-decoration: none;
     padding: 0.2rem 0.5rem;
-    border-radius: 6px;
+    border-radius: var(--radius-sm);
     background: color-mix(in srgb, var(--color-theme) 8%, transparent);
     transition: all 0.2s ease;
   }

--- a/src/pages/[lang]/series/index.astro
+++ b/src/pages/[lang]/series/index.astro
@@ -89,7 +89,7 @@ export const getStaticPaths = () =>
     align-items: center;
     justify-content: space-between;
     padding: var(--sp-m) var(--sp-l);
-    border-radius: 16px;
+    border-radius: var(--radius-md);
     background: color-mix(in srgb, var(--color-base) 95%, var(--color-main));
     border: 1px solid color-mix(in srgb, var(--color-theme) 15%, transparent);
     color: var(--color-main);

--- a/src/pages/[lang]/sitemap.astro
+++ b/src/pages/[lang]/sitemap.astro
@@ -195,7 +195,7 @@ export const getStaticPaths = () =>
   .tag-pill {
     display: inline-block;
     padding: 0.25rem 0.75rem;
-    border-radius: 50px;
+    border-radius: var(--radius-xl);
     background: color-mix(in srgb, var(--color-theme) 10%, transparent);
     color: var(--color-theme);
     text-decoration: none;

--- a/src/pages/[lang]/sponsor.astro
+++ b/src/pages/[lang]/sponsor.astro
@@ -81,7 +81,7 @@ export const getStaticPaths = () =>
 
   <section class="sponsor-section">
     <p class="tagline">
-      <strong>{locale === 'zh-cn' ? '感谢你支持这个博客，一起把测试做得更好。 🚀' : "Thanks for supporting this blog — let's make testing better together. 🚀"}</strong>
+      <strong>{locale === 'zh-cn' ? '感谢你支持这个博客，一起把测试做得更好。' : "Thanks for supporting this blog. Let's make testing better together."}</strong>
     </p>
   </section>
 </Layout>

--- a/src/pages/[lang]/tags/[tag].astro
+++ b/src/pages/[lang]/tags/[tag].astro
@@ -129,7 +129,7 @@ const breadcrumbs = [
   .post-card {
     display: flex;
     flex-direction: column;
-    border-radius: 20px;
+    border-radius: var(--radius-lg);
     overflow: hidden;
     background: color-mix(in srgb, var(--color-base) 95%, var(--color-main));
     border: 1px solid color-mix(in srgb, var(--color-theme) 15%, transparent);
@@ -241,7 +241,7 @@ const breadcrumbs = [
     color: var(--color-theme);
     text-decoration: none;
     padding: 0.2rem 0.5rem;
-    border-radius: 6px;
+    border-radius: var(--radius-sm);
     background: color-mix(in srgb, var(--color-theme) 8%, transparent);
     transition: all 0.2s ease;
   }

--- a/src/pages/[lang]/tags/index.astro
+++ b/src/pages/[lang]/tags/index.astro
@@ -88,7 +88,7 @@ export const getStaticPaths = () =>
     align-items: center;
     gap: 0.4rem;
     padding: 0.4rem 1rem;
-    border-radius: 50px;
+    border-radius: var(--radius-xl);
     background: color-mix(in srgb, var(--color-base) 95%, var(--color-main));
     border: 1px solid color-mix(in srgb, var(--color-theme) 15%, transparent);
     color: var(--color-main);

--- a/src/pages/[lang]/wiki/[...slug].astro
+++ b/src/pages/[lang]/wiki/[...slug].astro
@@ -172,19 +172,19 @@ const definedTermSchema = {
 
 <style>
   :global(.docs-sidebar-wrap) {
-    border-radius: 14px;
+    border-radius: var(--radius-md);
     overflow: hidden;
   }
 
   :global(.docs-sidebar) {
-    border-radius: 14px;
+    border-radius: var(--radius-md);
     overflow: hidden;
   }
 
   :global(.docs-sidebar-inner) {
     border-inline-start: none !important;
     border: 1px solid color-mix(in srgb, var(--color-theme) 18%, transparent) !important;
-    border-radius: 14px !important;
+    border-radius: var(--radius-md) !important;
     overflow: hidden;
     box-shadow: 0 4px 18px color-mix(in srgb, var(--color-main) 8%, transparent);
   }

--- a/src/pages/[lang]/wiki/index.astro
+++ b/src/pages/[lang]/wiki/index.astro
@@ -136,19 +136,19 @@ const definedTermSetSchema = !isEn ? {
 
 <style>
   :global(.docs-sidebar-wrap) {
-    border-radius: 14px;
+    border-radius: var(--radius-md);
     overflow: hidden;
   }
 
   :global(.docs-sidebar) {
-    border-radius: 14px;
+    border-radius: var(--radius-md);
     overflow: hidden;
   }
 
   :global(.docs-sidebar-inner) {
     border-inline-start: none !important;
     border: 1px solid color-mix(in srgb, var(--color-theme) 18%, transparent) !important;
-    border-radius: 14px !important;
+    border-radius: var(--radius-md) !important;
     overflow: hidden;
     box-shadow: 0 4px 18px color-mix(in srgb, var(--color-main) 8%, transparent);
   }
@@ -265,7 +265,7 @@ const definedTermSetSchema = !isEn ? {
     padding: var(--sp-m);
     padding-inline-start: var(--sp-m);
     border-inline-start: 3px solid color-mix(in srgb, var(--color-theme) 28%, transparent);
-    border-radius: 0 10px 10px 0;
+    border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
     background: color-mix(in srgb, var(--color-main) 4%, var(--color-base));
     scroll-margin-block-start: 1.5rem;
   }

--- a/src/pages/en/404.astro
+++ b/src/pages/en/404.astro
@@ -78,7 +78,7 @@ const homeUrl = "/en/";
     text-align: center;
     border: 4px dotted color-mix(in srgb, var(--color-caution) 40%, transparent);
     padding: var(--sp-l);
-    border-radius: 16px;
+    border-radius: var(--radius-md);
   }
   .container > h1 {
     color: var(--color-caution);

--- a/src/pages/zh-cn/404.astro
+++ b/src/pages/zh-cn/404.astro
@@ -74,7 +74,7 @@ const homeUrl = "/zh-cn/";
     text-align: center;
     border: 4px dotted color-mix(in srgb, var(--color-caution) 40%, transparent);
     padding: var(--sp-l);
-    border-radius: 16px;
+    border-radius: var(--radius-md);
   }
   .container > h1 {
     color: var(--color-caution);

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -2,7 +2,7 @@
   --color-theme: #4f46e5;
   --color-theme-focus: #4338ca;
   --color-theme-on-dark: #a5b4fc;
-  --color-accent: #14b8a6;
+  --color-theme-light: #818cf8;
   --color-base: #f8fafc;
   --color-canvas: #ffffff;
   --color-main: #0f172a;
@@ -23,9 +23,9 @@
   --glow-theme: rgba(79, 70, 229, 0.22);
   --gradient-hero:
     linear-gradient(135deg, rgba(79, 70, 229, 0.12) 0%, transparent 38%),
-    linear-gradient(315deg, rgba(20, 184, 166, 0.14) 0%, transparent 34%),
+    linear-gradient(315deg, rgba(67, 56, 202, 0.14) 0%, transparent 34%),
     linear-gradient(180deg, #ffffff 0%, #f8fafc 100%);
-  --gradient-theme: linear-gradient(135deg, var(--color-theme) 0%, var(--color-accent) 100%);
+  --gradient-theme: linear-gradient(135deg, var(--color-theme) 0%, var(--color-theme-light) 100%);
 
   --shadow-sm: 0 1px 2px rgba(15, 23, 42, 0.06);
   --shadow-md: 0 14px 35px rgba(15, 23, 42, 0.08);
@@ -84,7 +84,7 @@
   accent-color: var(--color-theme);
   background-image:
     linear-gradient(rgba(79, 70, 229, 0.035) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(20, 184, 166, 0.035) 1px, transparent 1px);
+    linear-gradient(90deg, rgba(79, 70, 229, 0.035) 1px, transparent 1px);
   background-size: 42px 42px;
 
   line-height: 1.47;

--- a/tests/e2e/specs/apple-home.spec.ts
+++ b/tests/e2e/specs/apple-home.spec.ts
@@ -1,19 +1,22 @@
 import { test, expect } from "@playwright/test";
 
-test.describe("apple homepage exploration", () => {
+test.describe("zenix homepage exploration", () => {
   for (const lang of ["zh-cn", "en"] as const) {
     test(`${lang} home shows hero, explore grid, latest posts`, async ({
       page,
       baseURL,
     }) => {
       await page.goto(`${baseURL}/${lang}/`);
-      await expect(page.locator(".home-apple-hero")).toBeVisible();
+      await expect(page.locator(".home-hero")).toBeVisible();
       await expect(page.locator("[data-home-task]")).toHaveCount(6);
       await expect(page.locator("[data-home-capability]")).toHaveCount(3);
       await expect(page.locator("[data-home-example]")).toHaveCount(3);
       await expect(page.locator(".home-explore-grid")).toBeVisible();
       await expect(page.locator(".home-latest-posts")).toBeVisible();
-      await expect(page.locator(".home-explore-grid .home-card")).toHaveCount(6);
+      // zh 比 en 多一张 blog 卡（en 的 wiki 语义由 AIWiki 卡覆盖）
+      await expect(page.locator(".home-explore-grid .home-card")).toHaveCount(
+        lang === "zh-cn" ? 7 : 6,
+      );
       await expect(page.locator(".home-prompts")).toBeVisible();
       await expect(page.locator(".home-projects")).toBeVisible();
       await expect(page.locator(".home-tags .tags-container")).toBeVisible();
@@ -24,13 +27,14 @@ test.describe("apple homepage exploration", () => {
 });
 
 test.describe("home information architecture", () => {
-  test("hero console cards link to wiki, skills, and prompts", async ({ page, baseURL }) => {
-    await page.goto(`${baseURL || ""}/zh-cn/`);
-    const links = page.locator(".home-hero-console .console-card");
-    await expect(links).toHaveCount(3);
-    await expect(links.nth(0)).toHaveAttribute("href", "/zh-cn/wiki/");
-    await expect(links.nth(1)).toHaveAttribute("href", "/zh-cn/qaskills/");
-    await expect(links.nth(2)).toHaveAttribute("href", "/zh-cn/prompts/");
+  test("hero CTAs link to blog and wiki entries", async ({ page, baseURL }) => {
+    for (const [lang, wikiPath] of [["zh-cn", "/zh-cn/wiki/"], ["en", "/en/AIWiki/"]] as const) {
+      await page.goto(`${baseURL || ""}/${lang}/`);
+      const ctas = page.locator(".home-hero__ctas a");
+      await expect(ctas).toHaveCount(2);
+      await expect(ctas.nth(0)).toHaveAttribute("href", `/${lang}/blog/`);
+      await expect(ctas.nth(1)).toHaveAttribute("href", wikiPath);
+    }
   });
 
   test("proof section keeps readable spacing between title and introduction", async ({ page, baseURL }) => {
@@ -70,30 +74,5 @@ test.describe("home information architecture", () => {
     expect(layout.width).toBeLessThanOrEqual(1120);
     expect(Math.abs(layout.left - layout.right)).toBeLessThanOrEqual(2);
     expect(layout.titleSize).toBe("34px");
-  });
-
-  test("zh-cn home exposes three primary entry cards", async ({ page, baseURL }) => {
-    await page.goto(`${baseURL || ""}/zh-cn/`, { waitUntil: "networkidle" });
-    const primaryEntries = page.locator(".home-primary-entry");
-    await expect(primaryEntries).toHaveCount(3);
-    await expect(primaryEntries.nth(0)).toContainText(/博客|Blog/);
-    await expect(primaryEntries.nth(1)).toContainText(/Wiki|百科/);
-    await expect(primaryEntries.nth(2)).toContainText(/QA|提示词|技能/);
-  });
-
-  test("en home exposes three primary entry cards", async ({ page, baseURL }) => {
-    await page.goto(`${baseURL || ""}/en/`, { waitUntil: "networkidle" });
-    const primaryEntries = page.locator(".home-primary-entry");
-    await expect(primaryEntries).toHaveCount(3);
-    await expect(primaryEntries.nth(0)).toContainText(/Blog/);
-    await expect(primaryEntries.nth(1)).toContainText(/Wiki/);
-    await expect(primaryEntries.nth(2)).toContainText(/QA|Prompt|Skill/);
-  });
-
-  test("task entry offers both skills and prompts without nested links", async ({ page, baseURL }) => {
-    await page.goto(`${baseURL || ""}/zh-cn/`);
-    const actionEntry = page.locator(".home-primary-entry--act");
-    await expect(actionEntry.getByRole("link", { name: /Skills/ })).toBeVisible();
-    await expect(actionEntry.getByRole("link", { name: /Prompts/ })).toBeVisible();
   });
 });

--- a/tests/e2e/specs/navigation.spec.ts
+++ b/tests/e2e/specs/navigation.spec.ts
@@ -3,7 +3,7 @@ import { test, expect } from "@playwright/test";
 test.describe("导航与首页内容", () => {
   test("en 首页：Hero、探索区、标签与最新文章可见", async ({ page, baseURL }) => {
     await page.goto((baseURL || "") + "/en/", { waitUntil: "networkidle" });
-    await expect(page.locator("main .home-apple-hero").first()).toBeVisible();
+    await expect(page.locator("main .home-hero").first()).toBeVisible();
     await expect(page.locator("main .home-explore-grid").first()).toBeVisible();
     await expect(page.locator("main .home-projects").first()).toBeVisible();
     await expect(page.locator("main .home-tags .tags-container").first()).toBeVisible();
@@ -12,7 +12,7 @@ test.describe("导航与首页内容", () => {
 
   test("zh-cn 首页：Hero、探索区、Guild、标签与最新文章可见", async ({ page, baseURL }) => {
     await page.goto((baseURL || "") + "/zh-cn/", { waitUntil: "networkidle" });
-    await expect(page.locator("main .home-apple-hero").first()).toBeVisible();
+    await expect(page.locator("main .home-hero").first()).toBeVisible();
     await expect(page.locator("main .home-explore-grid").first()).toBeVisible();
     await expect(page.locator("main .home-projects").first()).toBeVisible();
     await expect(page.locator("main .guild-showcase").first()).toBeVisible();

--- a/tests/e2e/specs/tracking-contract.spec.ts
+++ b/tests/e2e/specs/tracking-contract.spec.ts
@@ -15,7 +15,7 @@ test.describe("埋点契约", () => {
   test("首页入口点击事件包含 session_id", async ({ page, baseURL }) => {
     await page.goto((baseURL || "") + "/zh-cn/", { waitUntil: "networkidle" });
 
-    const entry = page.locator(".home-primary-entry[href='/zh-cn/blog/']");
+    const entry = page.locator(".home-hero__ctas a[href='/zh-cn/blog/']");
     await expect(entry).toBeVisible({ timeout: 10000 });
     await entry.evaluate((node) => {
       node.addEventListener(

--- a/tests/unit/zenixDesignTokens.test.ts
+++ b/tests/unit/zenixDesignTokens.test.ts
@@ -9,9 +9,10 @@ const baseCss = readFileSync(
 );
 
 describe("Zenix-inspired design tokens in base.css", () => {
-  it("uses indigo and teal as theme / accent colors", () => {
+  it("uses indigo as the single theme color", () => {
     expect(baseCss).toMatch(/--color-theme:\s*#4f46e5/i);
-    expect(baseCss).toMatch(/--color-accent:\s*#14b8a6/i);
+    // teal accent 已移除，indigo 为唯一主色
+    expect(baseCss).not.toMatch(/--color-accent:/i);
     expect(baseCss).not.toMatch(/--color-theme:\s*#ef4d1a/i);
   });
 


### PR DESCRIPTION
…e page

- Remove teal accent; indigo becomes the single theme color with converged gradients (new --color-theme-light token)
- Normalize all hardcoded border-radius values to the 8/12/18/pill token scale across ~30 files
- Slim home hero to title/subtitle/CTAs; remove fake console window and primary entry cards; merge entries into Explore grid (zh +blog card)
- Diversify home layouts: latest posts and projects become row lists; rename parchment bands to muted cool-gray
- Keep white glass header (clean dead black styles), merge Footer's duplicated CSS blocks with tokenized colors
- Replace emoji icons with Material Icons Sharp across guild, prompts, and sponsor surfaces; fix English em-dashes in UI copy
- Update home/tracking/navigation e2e specs and token contract test
- Add zenix-design.md as the current design standard; mark the Apple design doc as superseded