### PR TITLE
feat(nav): add Agent学习 entries and tidy header/footer menus

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -19,12 +19,12 @@ import {
   NAV_LINKS,
   NAV_ANALYTICS,
   SITE_TITLE,
-  SITE_SLOGAN
+  SITE_SLOGAN,
+  LEARNING_SITES
 } from "@/consts";
 
 const locale = Astro.currentLocale as Lang;
 const paths = getLocalePaths(Astro.url);
-const englishLearningUrl = "https://30-day-qa-english-learning-plan.inaodeng.com/";
 
 // 找到另一种语言的路径
 const otherLocalePath = paths.find(p => p.lang !== locale)?.path || (locale === 'zh-cn' ? '/en/' : '/zh-cn/');
@@ -70,14 +70,17 @@ const footerGroups = [
   },
   {
     key: "tools",
-    title: locale === "zh-cn" ? "工具内容" : "Tools",
+    title: locale === "zh-cn" ? "工具与学习" : "Tools",
     links: [
       { href: getRelativeLocaleUrl(locale, "/prompts"), label: typeof FOOTER_NAV_PROMPTS === 'string' ? FOOTER_NAV_PROMPTS : FOOTER_NAV_PROMPTS[locale] },
       { href: getRelativeLocaleUrl(locale, "/qaskills"), label: typeof FOOTER_NAV_QASKILLS === 'string' ? FOOTER_NAV_QASKILLS : FOOTER_NAV_QASKILLS[locale] },
       ...(locale === "zh-cn"
-        ? [{ href: englishLearningUrl, label: "英语学习", external: true }]
+        ? LEARNING_SITES.map((site) => ({
+            href: site.url,
+            label: site.label["zh-cn"],
+            external: true,
+          }))
         : []),
-      { href: getRelativeLocaleUrl(locale, "/sponsor"), label: typeof NAV_SPONSOR === 'string' ? NAV_SPONSOR : NAV_SPONSOR[locale] },
     ],
   },
   {
@@ -87,6 +90,7 @@ const footerGroups = [
       { href: getRelativeLocaleUrl(locale, "/copyright"), label: typeof NAV_COPYRIGHT === 'string' ? NAV_COPYRIGHT : NAV_COPYRIGHT[locale] },
       { href: getRelativeLocaleUrl(locale, "/privacy"), label: typeof NAV_PRIVACY === 'string' ? NAV_PRIVACY : NAV_PRIVACY[locale] },
       { href: getRelativeLocaleUrl(locale, "/links"), label: typeof NAV_LINKS === 'string' ? NAV_LINKS : NAV_LINKS[locale] },
+      { href: getRelativeLocaleUrl(locale, "/sponsor"), label: typeof NAV_SPONSOR === 'string' ? NAV_SPONSOR : NAV_SPONSOR[locale] },
       { href: "https://status.inaodeng.com", label: typeof NAV_STATUS === 'string' ? NAV_STATUS : NAV_STATUS[locale], external: true },
       { href: "https://analytics.inaodeng.com/dashboard?site=inaodeng.com", label: typeof NAV_ANALYTICS === 'string' ? NAV_ANALYTICS : NAV_ANALYTICS[locale], external: true },
       { href: getRelativeLocaleUrl(locale, "/rss.xml"), label: t.rss, external: true },
@@ -248,7 +252,7 @@ const footerGroups = [
   .lang-label {
     position: absolute;
     bottom: 10px;
-    font-size: 0.75rem;
+    font-size: var(--text-xs);
     font-weight: 900;
     padding: 2px 4px;
     border-radius: var(--radius-sm);
@@ -274,7 +278,7 @@ const footerGroups = [
 
   .footer-nav-group h2 {
     margin: 0 0 0.65rem;
-    font-size: 13px;
+    font-size: var(--text-sm);
     line-height: 1.4;
     font-weight: 700;
     color: var(--color-main);
@@ -291,7 +295,7 @@ const footerGroups = [
   .footer-nav a,
   .social-links a {
     color: var(--color-text-secondary);
-    font-size: 14px;
+    font-size: var(--text-sm);
     line-height: 2.2;
   }
 
@@ -325,7 +329,7 @@ const footerGroups = [
 
   .footer-slogan {
     margin: 0;
-    font-size: 14px;
+    font-size: var(--text-sm);
     font-weight: 400;
     letter-spacing: 0.02em;
     color: var(--color-text-tertiary);
@@ -359,7 +363,7 @@ const footerGroups = [
   }
 
   .license-link {
-    font-size: 14px;
+    font-size: var(--text-sm);
     color: inherit;
     text-decoration: none;
   }
@@ -369,7 +373,7 @@ const footerGroups = [
     flex-direction: column;
     align-items: center;
     gap: 0.5rem;
-    font-size: 12px;
+    font-size: var(--text-xs);
     opacity: 0.7;
     font-family: var(--english-font);
     letter-spacing: 0.05em;

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -15,8 +15,11 @@ import {
   NAV_GUIDES,
   NAV_AI_TESTING,
   NAV_MORE,
+  NAV_QA_PROMPTS,
+  NAV_QA_SKILLS,
   NAV_SPONSOR,
   NAV_SEARCH,
+  LEARNING_SITES,
 } from "@/consts";
 
 const t = useTranslations(Astro.currentLocale as Lang);
@@ -38,9 +41,24 @@ const isQASkillsSection = () => isSectionPath("/qaskills");
 const isProjectsSection = () => isSectionPath("/projects");
 const isSponsorSection = () => isSectionPath("/sponsor");
 const siteTitle = t(SITE_TITLE);
-const englishLearningUrl = "https://30-day-qa-english-learning-plan.inaodeng.com/";
 
-const navGroups = [
+type NavItem = {
+  key: string;
+  href: string;
+  label: string;
+  icon: string;
+  active: boolean;
+  external?: boolean;
+};
+
+type NavGroup = {
+  key: string;
+  label: string;
+  active: boolean;
+  items: NavItem[];
+};
+
+const navGroups: NavGroup[] = [
   {
     key: "encyclopedia",
     label: t(NAV_ENCYCLOPEDIA),
@@ -85,14 +103,14 @@ const navGroups = [
       {
         key: "qa-prompts",
         href: getRelativeLocaleUrl(locale, "/prompts"),
-        label: locale === "zh-cn" ? "软件测试提示词库" : "QA Prompt Library",
+        label: t(NAV_QA_PROMPTS),
         icon: "tips_and_updates",
         active: isPromptsSection(),
       },
       {
         key: "qa-skills",
         href: getRelativeLocaleUrl(locale, "/qaskills"),
-        label: locale === "zh-cn" ? "软件测试技能库" : "QA Skill Library",
+        label: t(NAV_QA_SKILLS),
         icon: "build",
         active: isQASkillsSection(),
       },
@@ -104,16 +122,14 @@ const navGroups = [
     active: isProjectsSection() || isSponsorSection(),
     items: [
       ...(locale === "zh-cn"
-        ? [
-            {
-              key: "english-learning",
-              href: englishLearningUrl,
-              label: "英语学习",
-              icon: "school",
-              active: false,
-              external: true,
-            },
-          ]
+        ? LEARNING_SITES.map((site) => ({
+            key: site.key,
+            href: site.url,
+            label: site.label["zh-cn"],
+            icon: site.icon,
+            active: false,
+            external: true,
+          }))
         : []),
       {
         key: "projects",
@@ -506,7 +522,7 @@ const mobilePriorityItems = [
   }
   h1 {
     margin: 0;
-    font-size: 19px;
+    font-size: var(--text-xl);
     font-family: var(--english-font);
     font-weight: 600;
     letter-spacing: -0.16px;
@@ -590,7 +606,7 @@ const mobilePriorityItems = [
     border-radius: 0;
     white-space: nowrap;
     text-decoration: none;
-    font-size: 16px;
+    font-size: var(--text-sm);
     font-weight: 400;
     letter-spacing: -0.16px;
     opacity: 0.8;
@@ -645,7 +661,7 @@ const mobilePriorityItems = [
     display: none;
   }
   .nav-group-chevron {
-    font-size: 19px;
+    font-size: var(--text-xl);
     opacity: 0.7;
     transition: transform 0.18s ease, opacity 0.18s ease;
   }
@@ -738,11 +754,11 @@ const mobilePriorityItems = [
     justify-content: center;
     width: 1.5rem;
     flex: 0 0 1.5rem;
-    font-size: 1.35rem;
+    font-size: var(--text-lg);
   }
   .nav-submenu-text {
     line-height: 1.25;
-    font-size: 16px;
+    font-size: var(--text-sm);
     font-weight: 400;
     letter-spacing: -0.16px;
     flex: 1 1 auto;
@@ -789,7 +805,7 @@ const mobilePriorityItems = [
     min-height: 44px;
     min-width: 60px;
     padding-inline: 8px;
-    font-size: 16px;
+    font-size: var(--text-sm);
     font-weight: 400;
     border: none;
     border-radius: var(--radius-sm);
@@ -802,14 +818,14 @@ const mobilePriorityItems = [
   .nav-tool :global(.icon-lang),
   .nav-tool :global(.icon-expand) {
     opacity: 0.85;
-    font-size: 22px;
+    font-size: var(--text-lg);
   }
   .nav-tool :global(.locale-panel) {
     border: 1px solid color-mix(in srgb, white 12%, transparent);
     box-shadow: 0 12px 28px color-mix(in srgb, black 45%, transparent);
   }
   .nav-tool :global(.locale-panel a) {
-    font-size: 16px;
+    font-size: var(--text-sm);
     font-weight: 400;
   }
   .nav-tool :global(.locale-panel a:hover) {
@@ -825,7 +841,7 @@ const mobilePriorityItems = [
     padding-inline: 0.55rem;
     white-space: nowrap;
     font: inherit;
-    font-size: 16px;
+    font-size: var(--text-sm);
     font-weight: 400;
     background: transparent;
     border: 1px solid transparent;
@@ -843,7 +859,7 @@ const mobilePriorityItems = [
     outline-offset: 1px;
   }
   .btn-icon .material-icons-sharp {
-    font-size: 24px;
+    font-size: var(--text-lg);
     color: currentColor;
     opacity: 0.95;
     flex-shrink: 0;
@@ -1000,7 +1016,7 @@ const mobilePriorityItems = [
       background: color-mix(in srgb, white 14%, transparent);
     }
     .mobile-priority-nav__icon {
-      font-size: 24px;
+      font-size: var(--text-lg);
     }
     .site-nav > ul > li > a,
     .nav-group-trigger {
@@ -1071,7 +1087,7 @@ const mobilePriorityItems = [
 
   h1 {
     font-family: var(--font-heading);
-    font-size: 18px;
+    font-size: var(--text-xl);
     font-weight: 800;
   }
 
@@ -1087,10 +1103,7 @@ const mobilePriorityItems = [
   .site-title-primary,
   .site-title-secondary,
   .site-brand-link > span:not(.site-title-cobrand) {
-    background: linear-gradient(90deg, var(--color-main), var(--color-theme) 55%, var(--color-theme-light));
-    -webkit-background-clip: text;
-    background-clip: text;
-    color: transparent;
+    color: var(--color-theme);
   }
 
   .site-title-cobrand-x {
@@ -1114,7 +1127,7 @@ const mobilePriorityItems = [
     min-height: 42px;
     padding: 0 0.9rem;
     border-radius: 999px;
-    font-size: 14px;
+    font-size: var(--text-sm);
     font-weight: 700;
     color: var(--color-text-secondary);
     opacity: 1;

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -138,6 +138,27 @@ export const NAV_MORE: Multilingual = {
   "zh-cn": "更多",
 };
 
+/** 站外学习计划站点（30 天系列）。目前仅在中文站的导航「更多」与页脚展示 */
+export const LEARNING_SITES: ReadonlyArray<{
+  key: string;
+  label: { en: string; "zh-cn": string };
+  url: string;
+  icon: string;
+}> = [
+  {
+    key: "agent-learning",
+    label: { en: "Agent Learning", "zh-cn": "Agent学习" },
+    url: "https://ai-agent-30-day-learning-plan.inaodeng.com/",
+    icon: "smart_toy",
+  },
+  {
+    key: "english-learning",
+    label: { en: "English Learning", "zh-cn": "英语学习" },
+    url: "https://30-day-qa-english-learning-plan.inaodeng.com/",
+    icon: "school",
+  },
+];
+
 /** 底部导航：软件测试百科 */
 export const FOOTER_NAV_QA_WIKI: Multilingual = {
   en: "QA Wiki",
@@ -727,6 +748,12 @@ export const FEATURED_PROJECTS: Array<{
 export const NAV_QA_PROMPTS: Multilingual = {
   en: "QA Prompts",
   "zh-cn": "提示词库",
+};
+
+/** 顶部导航：QA 技能库 */
+export const NAV_QA_SKILLS: Multilingual = {
+  en: "QA Skills",
+  "zh-cn": "技能库",
 };
 
 /** 提示词列表页 SEO 标题 */

--- a/tests/e2e/specs/header.spec.ts
+++ b/tests/e2e/specs/header.spec.ts
@@ -115,18 +115,31 @@ test.describe("Header 导航", () => {
     await expect(menuLink).toHaveAttribute("rel", "noopener noreferrer");
   });
 
+  test("zh-cn 首页：更多菜单包含 Agent学习 外链", async ({ page, baseURL }) => {
+    await page.goto((baseURL || "") + "/zh-cn/", { waitUntil: "domcontentloaded" });
+
+    const agentLearningUrl = "https://ai-agent-30-day-learning-plan.inaodeng.com/";
+    await page.locator("[data-nav-group='more'] summary").click();
+    const menuLink = page.locator("header nav a[data-nav-item='agent-learning']");
+    await expect(menuLink).toBeVisible();
+    await expect(menuLink).toContainText("Agent学习");
+    await expect(menuLink).toHaveAttribute("href", agentLearningUrl);
+    await expect(menuLink).toHaveAttribute("target", "_blank");
+    await expect(menuLink).toHaveAttribute("rel", "noopener noreferrer");
+  });
+
   test("zh-cn 首页：AI测试菜单下提示词库和技能库都可见", async ({ page, baseURL }) => {
     await page.goto((baseURL || "") + "/zh-cn/", { waitUntil: "domcontentloaded" });
     await page.locator("[data-nav-group='ai-testing'] summary").click();
-    await expect(page.locator("header nav a[data-nav-item='qa-prompts']")).toContainText("软件测试提示词库");
-    await expect(page.locator("header nav a[data-nav-item='qa-skills']")).toContainText("软件测试技能库");
+    await expect(page.locator("header nav a[data-nav-item='qa-prompts']")).toContainText("提示词库");
+    await expect(page.locator("header nav a[data-nav-item='qa-skills']")).toContainText("技能库");
   });
 
   test("en 首页：AI Testing 菜单下 Prompt/Skill 两个入口都可见", async ({ page, baseURL }) => {
     await page.goto((baseURL || "") + "/en/", { waitUntil: "domcontentloaded" });
     await page.locator("[data-nav-group='ai-testing'] summary").click();
-    await expect(page.locator("header nav a[data-nav-item='qa-prompts']")).toContainText("QA Prompt Library");
-    await expect(page.locator("header nav a[data-nav-item='qa-skills']")).toContainText("QA Skill Library");
+    await expect(page.locator("header nav a[data-nav-item='qa-prompts']")).toContainText("QA Prompts");
+    await expect(page.locator("header nav a[data-nav-item='qa-skills']")).toContainText("QA Skills");
   });
 
   test("en 首页：搜索按钮可见", async ({ page, baseURL }) => {

--- a/tests/e2e/specs/navigation.spec.ts
+++ b/tests/e2e/specs/navigation.spec.ts
@@ -147,6 +147,18 @@ test.describe("导航与首页内容", () => {
     await expect(footerLink).toHaveAttribute("rel", "noopener noreferrer");
   });
 
+  test("zh-cn 页脚包含「Agent学习」外链", async ({ page, baseURL }) => {
+    await page.goto((baseURL || "") + "/zh-cn/", { waitUntil: "networkidle" });
+    const footerLink = page.locator("footer .footer-nav a", { hasText: "Agent学习" }).first();
+    await expect(footerLink).toBeVisible();
+    await expect(footerLink).toHaveAttribute(
+      "href",
+      "https://ai-agent-30-day-learning-plan.inaodeng.com/",
+    );
+    await expect(footerLink).toHaveAttribute("target", "_blank");
+    await expect(footerLink).toHaveAttribute("rel", "noopener noreferrer");
+  });
+
   test("zh-cn 从首页点击「更多 > 项目」进入项目页", async ({ page, baseURL }) => {
     await page.goto((baseURL || "") + "/zh-cn/", { waitUntil: "networkidle" });
     await page.locator("header nav [data-nav-group='more'] summary").click();


### PR DESCRIPTION
- Add Agent学习 external link to zh-cn "更多" menu and footer, alongside 英语学习, via a shared LEARNING_SITES const in src/consts.ts
- Rename footer "工具内容" group to "工具与学习"; move Support into the Site group where it belongs
- Shorten header dropdown labels to 提示词库/技能库 (QA Prompts/QA Skills), consistent with the short-in-header / long-in-footer naming pattern
- Replace off-ramp literal font sizes with --text-* design tokens and swap the brand gradient text for a solid indigo color; impeccable design checks now pass clean on both shell components