### PR TITLE
feat(nav): add Playwright学习 link to 更多 menu and footer

### DIFF
--- a/src/consts.ts
+++ b/src/consts.ts
@@ -157,6 +157,12 @@ export const LEARNING_SITES: ReadonlyArray<{
     url: "https://30-day-qa-english-learning-plan.inaodeng.com/",
     icon: "school",
   },
+  {
+    key: "playwright-learning",
+    label: { en: "Playwright Learning", "zh-cn": "Playwright学习" },
+    url: "https://30-day-qa-playwright-learning-plan.inaodeng.com/",
+    icon: "science",
+  },
 ];
 
 /** 底部导航：软件测试百科 */

--- a/tests/e2e/specs/header.spec.ts
+++ b/tests/e2e/specs/header.spec.ts
@@ -128,6 +128,19 @@ test.describe("Header 导航", () => {
     await expect(menuLink).toHaveAttribute("rel", "noopener noreferrer");
   });
 
+  test("zh-cn 首页：更多菜单包含 Playwright学习 外链", async ({ page, baseURL }) => {
+    await page.goto((baseURL || "") + "/zh-cn/", { waitUntil: "domcontentloaded" });
+
+    const playwrightLearningUrl = "https://30-day-qa-playwright-learning-plan.inaodeng.com/";
+    await page.locator("[data-nav-group='more'] summary").click();
+    const menuLink = page.locator("header nav a[data-nav-item='playwright-learning']");
+    await expect(menuLink).toBeVisible();
+    await expect(menuLink).toContainText("Playwright学习");
+    await expect(menuLink).toHaveAttribute("href", playwrightLearningUrl);
+    await expect(menuLink).toHaveAttribute("target", "_blank");
+    await expect(menuLink).toHaveAttribute("rel", "noopener noreferrer");
+  });
+
   test("zh-cn 首页：AI测试菜单下提示词库和技能库都可见", async ({ page, baseURL }) => {
     await page.goto((baseURL || "") + "/zh-cn/", { waitUntil: "domcontentloaded" });
     await page.locator("[data-nav-group='ai-testing'] summary").click();

--- a/tests/e2e/specs/navigation.spec.ts
+++ b/tests/e2e/specs/navigation.spec.ts
@@ -159,6 +159,18 @@ test.describe("导航与首页内容", () => {
     await expect(footerLink).toHaveAttribute("rel", "noopener noreferrer");
   });
 
+  test("zh-cn 页脚包含「Playwright学习」外链", async ({ page, baseURL }) => {
+    await page.goto((baseURL || "") + "/zh-cn/", { waitUntil: "networkidle" });
+    const footerLink = page.locator("footer .footer-nav a", { hasText: "Playwright学习" }).first();
+    await expect(footerLink).toBeVisible();
+    await expect(footerLink).toHaveAttribute(
+      "href",
+      "https://30-day-qa-playwright-learning-plan.inaodeng.com/",
+    );
+    await expect(footerLink).toHaveAttribute("target", "_blank");
+    await expect(footerLink).toHaveAttribute("rel", "noopener noreferrer");
+  });
+
   test("zh-cn 从首页点击「更多 > 项目」进入项目页", async ({ page, baseURL }) => {
     await page.goto((baseURL || "") + "/zh-cn/", { waitUntil: "networkidle" });
     await page.locator("header nav [data-nav-group='more'] summary").click();


### PR DESCRIPTION
Add the 30-day Playwright learning plan site to the zh-cn 更多 dropdown and footer 工具与学习 group, with matching e2e assertions.