### PR TITLE
fix(ui): restore home hero accessibility test contract

### DIFF
--- a/src/components/home/HomeGlassHero.astro
+++ b/src/components/home/HomeGlassHero.astro
@@ -12,7 +12,7 @@ const t = useTranslations(locale);
   <div class="glass-hero__panel">
     <span class="glass-hero__accent" aria-hidden="true"></span>
     <h1 id="glass-hero-title">{t(HOME_HERO_TITLE)}</h1>
-    <p class="glass-hero__summary">{t(HOME_HERO_SUBTITLE)}</p>
+    <p class="glass-hero__summary home-hero__subtitle">{t(HOME_HERO_SUBTITLE)}</p>
     <div class="glass-hero__actions home-hero__ctas">
       <a class="pill-cta pill-cta--primary" href="#home-task-navigator">{t(HOME_CTA_TASK)} <span aria-hidden="true">→</span></a>
       <a class="pill-cta pill-cta--ghost" href={getRelativeLocaleUrl(locale, "/qaskills")}>{t(HOME_CTA_SKILLS)} <span aria-hidden="true">↗</span></a>


### PR DESCRIPTION
## Summary
- restore the stable `.home-hero__subtitle` hook on the diffuse-glass home hero subtitle
- keep the current visual styling unchanged
- fix the two Playwright accessibility checks that failed after PR #90

## Verification
- `npm run build`: passed (1107 pages)
- `npm test`: passed (107 tests)
- targeted Playwright accessibility checks: 2 passed
- `git diff --check`: passed

Follow-up to #90.